### PR TITLE
add bytes_recvd to Stats and stats.bro for reporting

### DIFF
--- a/scripts/base/init-bare.bro
+++ b/scripts/base/init-bare.bro
@@ -440,6 +440,7 @@ type NetStats: record {
 	## packet capture system, this value may not be available and will then
 	## be always set to zero.
 	pkts_link:    count &default=0;
+	bytes_recvd:  count &default=0;	##< Bytes received by Bro.
 };
 
 ## Statistics about Bro's resource consumption.

--- a/scripts/policy/misc/stats.bro
+++ b/scripts/policy/misc/stats.bro
@@ -39,6 +39,9 @@ export {
 		## Number of packets seen on the link since the last stats
 		## interval if reading live traffic.
 		pkts_link:     count     &log &optional;
+		## Number of bytes received since the last stats interval if
+		## reading live traffic.
+		bytes_recv:   count     &log &optional;
 	};
 
 	## Event to catch stats as they are written to the logging stream.
@@ -74,6 +77,7 @@ event check_stats(last_ts: time, last_ns: NetStats, last_res: bro_resources)
 		info$pkts_recv = ns$pkts_recvd - last_ns$pkts_recvd;
 		info$pkts_dropped = ns$pkts_dropped  - last_ns$pkts_dropped;
 		info$pkts_link = ns$pkts_link  - last_ns$pkts_link;
+		info$bytes_recv = ns$bytes_recvd  - last_ns$bytes_recvd;
 		}
 
 	Log::write(Stats::LOG, info);

--- a/src/bro.bif
+++ b/src/bro.bif
@@ -1675,6 +1675,7 @@ function net_stats%(%): NetStats
 	unsigned int recv = 0;
 	unsigned int drop = 0;
 	unsigned int link = 0;
+	uint64 bytes = 0;
 
 	const iosource::Manager::PktSrcList& pkt_srcs(iosource_mgr->GetPktSrcs());
 
@@ -1688,12 +1689,14 @@ function net_stats%(%): NetStats
 		recv += stat.received;
 		drop += stat.dropped;
 		link += stat.link;
+		bytes += stat.bytes;
 		}
 
 	RecordVal* ns = new RecordVal(net_stats);
 	ns->Assign(0, new Val(recv, TYPE_COUNT));
 	ns->Assign(1, new Val(drop, TYPE_COUNT));
 	ns->Assign(2, new Val(link, TYPE_COUNT));
+	ns->Assign(3, new Val(bytes, TYPE_COUNT));
 
 	return ns;
 	%}

--- a/src/iosource/PktSrc.h
+++ b/src/iosource/PktSrc.h
@@ -38,7 +38,12 @@ public:
 		 */
 		unsigned int link;
 
-		Stats()	{ received = dropped = link = 0; }
+    /**
+     * Bytes received by source after filtering (w/o drops).
+     */
+    uint64 bytes;
+
+		Stats()	{ received = dropped = link = bytes = 0; }
 	};
 
 	/**

--- a/src/iosource/pcap/Source.cc
+++ b/src/iosource/pcap/Source.cc
@@ -180,6 +180,7 @@ bool PcapSource::ExtractNextPacket(Packet* pkt)
 	last_hdr = current_hdr;
 	last_data = data;
 	++stats.received;
+  stats.bytes += current_hdr.len;
 	return true;
 	}
 
@@ -219,7 +220,7 @@ bool PcapSource::SetFilter(int index)
 
 #ifndef HAVE_LINUX
 	// Linux doesn't clear counters when resetting filter.
-	stats.received = stats.dropped = stats.link = 0;
+	stats.received = stats.dropped = stats.link = stats.bytes = 0;
 #endif
 
 	return true;
@@ -230,7 +231,7 @@ void PcapSource::Statistics(Stats* s)
 	char errbuf[PCAP_ERRBUF_SIZE];
 
 	if ( ! (props.is_live && pd) )
-		s->received = s->dropped = s->link = 0;
+		s->received = s->dropped = s->link = s->bytes = 0;
 
 	else
 		{
@@ -238,7 +239,7 @@ void PcapSource::Statistics(Stats* s)
 		if ( pcap_stats(pd, &pstat) < 0 )
 			{
 			PcapError();
-			s->received = s->dropped = s->link = 0;
+			s->received = s->dropped = s->link = s->bytes = 0;
 			}
 
 		else
@@ -249,6 +250,8 @@ void PcapSource::Statistics(Stats* s)
 		}
 
 	s->received = stats.received;
+
+  s->bytes = stats.bytes;
 
 	if ( ! props.is_live )
 		s->dropped = 0;


### PR DESCRIPTION
Used libpcap-provided packet hdr.len to count bytes and get an idea of bandwidth/throughput for gauging live monitoring and for general interest.