### PR TITLE
Add ssl data to rdp log

### DIFF
--- a/scripts/base/protocols/rdp/main.bro
+++ b/scripts/base/protocols/rdp/main.bro
@@ -36,6 +36,8 @@ export {
 		encryption_level:      string  &log &optional;
 		## Encryption method of the connection. 
 		encryption_method:     string  &log &optional;
+		## Flag the connection if it was seen over SSL.
+                ssl:                    bool    &log &default=F;
 		};
 
 	## If true, detach the RDP analyzer from the connection to prevent
@@ -194,6 +196,15 @@ event protocol_violation(c: connection, atype: Analyzer::Tag, aid: count, reason
 	if ( c?$rdp )
 		write_log(c);
 	}
+	
+event ssl_established(c: connection) &priority=-5
+        {
+        if ( c?$rdp )
+                {
+                c$rdp$ssl = T;
+                write_log(c);
+                }
+        }
 
 event connection_state_remove(c: connection) &priority=-5
 	{

--- a/scripts/base/protocols/rdp/main.bro
+++ b/scripts/base/protocols/rdp/main.bro
@@ -37,7 +37,7 @@ export {
 		## Encryption method of the connection. 
 		encryption_method:     string  &log &optional;
 		## Flag the connection if it was seen over SSL.
-                ssl:                    bool    &log &default=F;
+                ssl:                   bool    &log &default=F;
 		};
 
 	## If true, detach the RDP analyzer from the connection to prevent


### PR DESCRIPTION
Added an ssl flag in the rdp log to identify the RDP session as being seen over SSL.
Added ssl_established event to set the ssl flag to true and write the rdp data to the log.