### PR TITLE
Add defensive check for localtime_r() call

### DIFF
--- a/src/util.cc
+++ b/src/util.cc
@@ -1356,9 +1356,13 @@ double calc_next_rotate(double current, double interval, double base)
 	time_t teatime = time_t(current);
 
 	struct tm t;
-	t = *localtime_r(&teatime, &t);
-	t.tm_hour = t.tm_min = t.tm_sec = 0;
-	double startofday = mktime(&t);
+	if ( ! localtime_r(&teatime, &t) )
+		{
+		reporter->Error("calc_next_rotate(): can't parse current time");
+
+		// fall back to the method used if no base time is given
+		base = -1;
+		}
 
 	if ( base < 0 )
 		// No base time given. To get nice timestamps, we round
@@ -1367,6 +1371,8 @@ double calc_next_rotate(double current, double interval, double base)
 			+ interval - current;
 
 	// current < startofday + base + i * interval <= current + interval
+	t.tm_hour = t.tm_min = t.tm_sec = 0;
+	double startofday = mktime(&t);
 	return startofday + base +
 		ceil((current - startofday - base) / interval) * interval -
 			current;


### PR DESCRIPTION
Some time around 3 years ago, I ran into a weird issue where the value fed as current to calc_next_rotate() was weird.  I think it was zero, but cannot recall for sure.  The call to localtime_r() would fail, returning NULL.  Since that result wasn't checked before use, it would SEGV.

I developed this patch, but must have never submitted it.  While it doesn't fix the root cause of the bad value for current, which I don't think I was ever able to figure out, it adds a defensive check for the return value of localtime_r(), and falls back to a different method if the call had failed.

Please verify that the error report is appropriate and the fallback method does what I think it should, as I'm sure my understanding of the execution flow around this function isn't as good as others.