### PR TITLE
Seems to fix a case where an entry in the table may be null on insert.

### DIFF
--- a/src/Dict.cc
+++ b/src/Dict.cc
@@ -416,13 +416,15 @@ void* Dictionary::Insert(DictEntry* new_entry, int copy_key)
 			{
 			DictEntry* entry = (*chain)[i];
 
-			if ( entry->hash == new_entry->hash &&
-			     entry->len == n &&
-			     ! memcmp(entry->key, new_entry->key, n) )
-				{
-				void* old_value = entry->value;
-				entry->value = new_entry->value;
-				return old_value;
+			if ( entry ) {
+				if ( entry->hash == new_entry->hash &&
+				     entry->len == n &&
+				     ! memcmp(entry->key, new_entry->key, n) )
+					{
+					void* old_value = entry->value;
+					entry->value = new_entry->value;
+					return old_value;
+					}
 				}
 			}
 		}

--- a/src/Reporter.cc
+++ b/src/Reporter.cc
@@ -88,7 +88,11 @@ void Reporter::FatalError(const char* fmt, ...)
 	va_end(ap);
 
 	set_processing_status("TERMINATED", "fatal_error");
+#ifdef DEBUG
+	abort();
+#else
 	exit(1);
+#endif // DEBUG
 	}
 
 void Reporter::FatalErrorWithCore(const char* fmt, ...)
@@ -393,4 +397,3 @@ void Reporter::DoLog(const char* prefix, EventHandlerPtr event, FILE* out,
 	if ( alloced )
 		free(alloced);
 	}
-


### PR DESCRIPTION
#0  0x0000000000713b87 in Dictionary::Insert (this=0x1339840, new_entry=0xb18a9d0, copy_key=0) at /root/psdev/bro/src/Dict.cc:419
#1  0x00000000007130b0 in Dictionary::Insert (this=0x1339840, key=0xa23f6d0, key_size=36, hash=658668102, val=0x67fde40, copy_key=0) at /root/psdev/bro/src/Dict.cc:158
#2  0x00000000006cb508 in Dictionary::Insert (this=0x1339840, key=0x7ffff4ba81b0, val=0x67fde40) at /root/psdev/bro/src/Dict.h:47

(gdb) print *this
$59 = {_vptr.Dictionary = 0xaf7810, tbl = 0x215b400, num_buckets = 1347, num_entries = 3879, max_num_entries = 4042, den_thresh = 3, thresh_entries = 4041, tbl2 = 0x1afcc9e0,
  num_buckets2 = 2695, num_entries2 = 181, max_num_entries2 = 181, den_thresh2 = 3, thresh_entries2 = 8085, tbl_next_ind = 60, order = 0x133bfb0, delete_func = 0,
  cookies = {<BaseList> = {entry = 0x133d790, chunk_size = 10, max_entries = 10, num_entries = 0}, <No data fields>}}

(gdb) print *tbl
$60 = (DictEntryPList *) 0x0