### PR TITLE
Add PROXY-AUTHORIZATION header to http.log

### DIFF
--- a/scripts/base/protocols/http/main.bro
+++ b/scripts/base/protocols/http/main.bro
@@ -257,7 +257,7 @@ event http_header(c: connection, is_orig: bool, name: string, value: string) &pr
 				add c$http$proxied[fmt("%s -> %s", name, value)];
 				}
 
-		else if ( name == "AUTHORIZATION" )
+		else if ( name == "AUTHORIZATION" || name == "PROXY-AUTHORIZATION" )
 			{
 			if ( /^[bB][aA][sS][iI][cC] / in value )
 				{


### PR DESCRIPTION
Added the PROXY-AUTHORIZATION header to http/main so that proxy usernames and passwords can be decoded. This header follows the same syntax as the AUTHORIZATION header, so no additional changes need to be made to the remaining code.