### PR TITLE
Updated detection of Flash and AdobeAIR.

### DIFF
--- a/scripts/base/frameworks/software/main.bro
+++ b/scripts/base/frameworks/software/main.bro
@@ -280,6 +280,13 @@ function parse_mozilla(unparsed_version: string): Description
 				v = parse(parts[1])$version;
 			}
 		}
+	else if ( /AdobeAIR\/[0-9\.]*/ in unparsed_version )
+		{
+		software_name = "AdobeAIR";
+		parts = split_string_all(unparsed_version, /AdobeAIR\/[0-9\.]*/);
+		if ( 1 in parts )
+			v = parse(parts[1])$version;
+		}
 	else if ( /AppleWebKit\/[0-9\.]*/ in unparsed_version )
 		{
 		software_name = "Unspecified WebKit";

--- a/testing/btest/Baseline/scripts.base.frameworks.software.version-parsing/output
+++ b/testing/btest/Baseline/scripts.base.frameworks.software.version-parsing/output
@@ -8,6 +8,7 @@ success on: Wget/1.11.4 (Red Hat modified)
 success on: curl/7.15.1 (i486-pc-linux-gnu) libcurl/7.15.1 OpenSSL/0.9.8a zlib/1.2.3 libidn/0.5.18
 success on: Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_3_2 like Mac OS X; en-us) AppleWebKit/533.17.9 (KHTML, like Gecko) Version/5.0.2 Mobile/8H7 Safari/6533.18.5
 success on: Opera/9.80 (Windows NT 6.1; U; sv) Presto/2.7.62 Version/11.01
+success on: Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en) AppleWebKit/531.9 (KHTML, like Gecko) AdobeAIR/2.6
 success on: (vsFTPd 2.0.5)
 success on: OpenSSH_4.4
 success on: Mozilla/4.0 (compatible; MSIE 8.0; Android 2.2.2; Linux; Opera Mobi/ADR-1103311355; en) Opera 11.00

--- a/testing/btest/scripts/base/frameworks/software/version-parsing.bro
+++ b/testing/btest/scripts/base/frameworks/software/version-parsing.bro
@@ -69,6 +69,8 @@ global matched_software: table[string] of Software::Description = {
 		[$name="Safari", $version=[$major=5,$minor=0,$minor2=4], $unparsed_version=""],
 	["Mozilla/5.0 (iPod; U; CPU iPhone OS 4_0 like Mac OS X; en-us) AppleWebKit/532.9 (KHTML, like Gecko) Version/4.0.5 Mobile/8A293 Safari/6531.22.7"] = 
 		[$name="Safari", $version=[$major=4,$minor=0,$minor2=5,$addl="Mobile"], $unparsed_version=""],
+	["Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en) AppleWebKit/531.9 (KHTML, like Gecko) AdobeAIR/2.6"] =
+		[$name="AdobeAIR", $version=[$major=2,$minor=6], $unparsed_version=""],
 	["Opera/9.80 (J2ME/MIDP; Opera Mini/9.80 (S60; SymbOS; Opera Mobi/23.348; U; en) Presto/2.5.25 Version/10.54"] = 
 		[$name="Opera Mini", $version=[$major=10,$minor=54], $unparsed_version=""],
 	["Opera/9.80 (J2ME/MIDP; Opera Mini/5.0.18741/18.794; U; en) Presto/2.4.15"] =


### PR DESCRIPTION
## Changes
This small patch introduces the following changes:
* adds detection of AdobeAIR
* emphasizes the use of Flash by AdobeAIR
* allows the detection of Flash used by Chrome

## Background
Due to the recently published Flash vulnerabilities, we wanted to inform users about outdated Flash versions. As AdobeAIR uses a separate Flash version, the requests to update Flash lead to some confusion.

## References
* AdobeAIR user agent string: http://help.adobe.com/en_US/AIR/1.5/devappshtml/WS5b3ccc516d4fbf351e63e3d118666ade46-7e7b.html
* Chrome flash indication: https://codereview.chromium.org/10886047/

