### PR TITLE
Add hook 'HookAddToAnalyzerTree' to support TCPRS plugin

### DIFF
--- a/src/analyzer/Manager.cc
+++ b/src/analyzer/Manager.cc
@@ -505,6 +505,8 @@ bool Manager::BuildInitialAnalyzerTree(Connection* conn)
 	if ( ! analyzed )
 		conn->SetLifetime(non_analyzed_lifetime);
 
+	PLUGIN_HOOK_VOID(HOOK_ADD_TO_ANALYZER_TREE, HookAddToAnalyzerTree(conn));
+
 	return true;
 	}
 

--- a/src/plugin/Manager.h
+++ b/src/plugin/Manager.h
@@ -264,6 +264,8 @@ public:
 	 */
 	void HookUpdateNetworkTime(double network_time) const;
 
+	void HookAddToAnalyzerTree(Connection *conn) const;
+
 	/**
 	 * Hook that informs plugins that the event queue is being drained.
 	 */

--- a/src/plugin/Plugin.cc
+++ b/src/plugin/Plugin.cc
@@ -23,6 +23,7 @@ const char* plugin::hook_name(HookType h)
 		"DrainEvents",
 		"UpdateNetworkTime",
 		"BroObjDtor",
+		"AddToAnalyzerTree",
 		// MetaHooks
 		"MetaHookPre",
 		"MetaHookPost",
@@ -307,6 +308,10 @@ void Plugin::HookDrainEvents()
 	}
 
 void Plugin::HookUpdateNetworkTime(double network_time)
+	{
+	}
+
+void Plugin::HookAddToAnalyzerTree(Connection *conn)
 	{
 	}
 

--- a/src/plugin/Plugin.h
+++ b/src/plugin/Plugin.h
@@ -39,6 +39,7 @@ enum HookType {
 	HOOK_DRAIN_EVENTS,		//< Activates Plugin::HookDrainEvents()
 	HOOK_UPDATE_NETWORK_TIME,	//< Activates Plugin::HookUpdateNetworkTime.
 	HOOK_BRO_OBJ_DTOR,		//< Activates Plugin::HookBroObjDtor.
+	HOOK_ADD_TO_ANALYZER_TREE, // Activates Plugin::HookAddToAnalyzerTree
 
 	// Meta hooks.
 	META_HOOK_PRE,			//< Activates Plugin::MetaHookPre().
@@ -635,6 +636,8 @@ protected:
 	 * @param network_time The new network time.
 	 */
 	virtual void HookUpdateNetworkTime(double network_time);
+
+	virtual void HookAddToAnalyzerTree(Connection *conn);
 
 	/**
 	 * Hook for destruction of objects registered with


### PR DESCRIPTION
This commit introduces a new hook, HookAddToAnalyzerTree, which
allows plugins to add a new analyzer to the analyzer tree during
analyzer tree creation. This hook is necessary to support the
TCPRS plugin.

Additionally, the order in which the scripts were loaded has been
changed to address a problem with undefined variable errors due
to load order issues.

Signed-off-by: James Swaro <james.swaro@gmail.com>