### PR TITLE
Update to SIP protocol

### DIFF
--- a/src/analyzer/protocol/sip/sip-protocol.pac
+++ b/src/analyzer/protocol/sip/sip-protocol.pac
@@ -10,6 +10,7 @@ type SIP_COLON	= RE/:/;
 type SIP_TO_EOL = RE/[^\r\n]*/;
 type SIP_EOL    = RE/(\r\n){1,2}/;
 type SIP_URI    = RE/[[:alnum:]@[:punct:]]+/;
+type SIP_NL	= RE/(\r\n)/;
 
 type SIP_PDU(is_orig: bool) = case is_orig of {
 	true  ->	request:	SIP_Request;
@@ -18,13 +19,13 @@ type SIP_PDU(is_orig: bool) = case is_orig of {
 
 type SIP_Request = record {
 	request:	SIP_RequestLine;
-	newline:	padding[2];
+	newline:	SIP_NL;
 	msg:		SIP_Message;
 };
 
 type SIP_Reply = record {
 	reply:		SIP_ReplyLine;
-	newline:	padding[2];
+	newline:	SIP_NL;
 	msg:		SIP_Message;
 };
 
@@ -67,6 +68,7 @@ type SIP_Message = record {
 type SIP_HEADER_NAME = RE/[^: \t]+/;
 type SIP_Header = record {
 	name:	SIP_HEADER_NAME;
+	:	SIP_WS;
 	:	SIP_COLON;
 	:	SIP_WS;
 	value:	SIP_TO_EOL;


### PR DESCRIPTION
- Change SIP header - according to RFC3261, space on both sides of ':' should be expected.

- Change to SIP_request and SIP_Reply - We encountered packets that do not contain newline and msg part of request/reply. Bro parser was segfaulting with:
0x0000000001227de2 in binpac::SIP::SIP_Headers::Parse (this=0x1c709120,
    t_begin_of_data=0x2aaaadd56348 <Address 0x2aaaadd56348 out of bounds>,
    t_end_of_data=0x2aaaadd56346 <Address 0x2aaaadd56346 out of bounds>, t_context=0x1c6f9a90)
    at src/analyzer/protocol/sip/sip_pac.cc:586
This small change should have it fixed.