### PR TITLE
hash-all-files.bro depends on base/files/hash

### DIFF
--- a/scripts/policy/frameworks/files/hash-all-files.bro
+++ b/scripts/policy/frameworks/files/hash-all-files.bro
@@ -1,5 +1,7 @@
 ##! Perform MD5 and SHA1 hashing on all files.
 
+@load base/files/hash
+
 event file_new(f: fa_file)
 	{
 	Files::add_analyzer(f, Files::ANALYZER_MD5);


### PR DESCRIPTION
Even though base/files/hash is loaded by init-default.bro it is required when running in bare mode.
