### PR TITLE
update ParseRequest to handle missing uri

### DIFF
--- a/src/analyzer/protocol/http/HTTP.cc
+++ b/src/analyzer/protocol/http/HTTP.cc
@@ -1249,6 +1249,12 @@ int HTTP_Analyzer::ParseRequest(const char* line, const char* end_of_line)
 			break;
 		}
 
+    if ( end_of_uri >= end_of_line )
+        {
+            Weird("missing_HTTP_uri");
+            return 0;
+        }
+
 	for ( version_start = end_of_uri; version_start < end_of_line; ++version_start )
 		{
 		end_of_uri = version_start;


### PR DESCRIPTION
If a request is missing a `uri`, the version string will be parsed as the `uri`.  For example, an invalid request (ie. `GET HTTP/1.1`), will treat the `uri` as `HTTP/1.1`. 

This pr checks to see if the uri terminates at the end of the line.  If so, it may represent a missing uri or other weirdness.