### PR TITLE
Correct irc_privmsg_message handling.

### DIFF
--- a/src/analyzer/protocol/irc/IRC.cc
+++ b/src/analyzer/protocol/irc/IRC.cc
@@ -601,7 +601,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 		return;
 		}
 
-	else if ( irc_privmsg_message || (irc_dcc_message && command == "PRIVMSG") )
+	else if ( ( irc_privmsg_message || irc_dcc_message ) && command == "PRIVMSG")
 		{
 		unsigned int pos = params.find(' ');
 		if ( pos >= params.size() )


### PR DESCRIPTION
Due to a logic bug, once an "irc_privmsg_message" event handler is created, *all* IRC events were routed down the "PRIVMSG" code path, generally creating a Weird("irc_invalid_privmsg_message_format") event and terminating the inspection.