### PR TITLE
Add disable_all_analyzers for connection shunting options

### DIFF
--- a/src/Conn.cc
+++ b/src/Conn.cc
@@ -419,6 +419,11 @@ analyzer::Analyzer* Connection::FindAnalyzer(const char* name)
 	return root_analyzer->FindChild(name);
 	}
 
+const analyzer::analyzer_list& Connection::GetAnalyzers()
+    {
+    return root_analyzer->GetChildren();
+    }
+
 void Connection::AppendAddl(const char* str)
 	{
 	Unref(BuildConnVal());

--- a/src/Conn.h
+++ b/src/Conn.h
@@ -107,7 +107,9 @@ public:
 	analyzer::Analyzer* FindAnalyzer(analyzer::ID id);
 	analyzer::Analyzer* FindAnalyzer(analyzer::Tag tag);	// find first in tree.
 	analyzer::Analyzer* FindAnalyzer(const char* name);	// find first in tree.
-
+    
+    const analyzer::analyzer_list& GetAnalyzers();
+    
 	TransportProto ConnTransport() const { return proto; }
 
 	// True if we should record subsequent packets (either headers or

--- a/src/bro.bif
+++ b/src/bro.bif
@@ -4051,6 +4051,30 @@ function disable_analyzer%(cid: conn_id, aid: count%) : bool
 	return new Val(1, TYPE_BOOL);
 	%}
 
+
+## Disables all analyzers associated to cid
+##
+## cid: The connection identifier
+##
+## Returns: True if the connection identified by *cid* exists and has analyzers attached
+##
+function disable_all_analyzers%(cid: conn_id%) : bool
+	%{
+	Connection* c = sessions->FindConnection(cid);
+	if ( ! c )
+		{
+		return new Val(0, TYPE_BOOL);
+		}
+
+	const analyzer::analyzer_list& a_l = c->GetAnalyzers();
+	for ( analyzer::analyzer_list::const_iterator al_iter = a_l.begin(); al_iter != a_l.end(); al_iter++ )
+		{
+		(*al_iter)->Remove();
+		}
+
+	return new Val(1, TYPE_BOOL);
+	%}
+
 ## Informs Bro that it should skip any further processing of the contents of
 ## a given connection. In particular, Bro will refrain from reassembling the
 ## TCP byte stream and from generating events relating to any analyzers that


### PR DESCRIPTION
Tracking an analyzer attached to a connection is not always desirable, given so many scripts have to be changed. In the event of a bulk connection, it is nice to be able to use ConnThreshold and simply disable all attached analyzers for a connection surpassing the threshold. 