### PR TITLE
DNS TTL responses are to be unsigned.

### DIFF
--- a/src/analyzer/protocol/dns/DNS.h
+++ b/src/analyzer/protocol/dns/DNS.h
@@ -132,7 +132,7 @@ public:
 	StringVal* query_name;
 	RR_Type atype;
 	int aclass;	///< normally = 1, inet
-	int ttl;
+	uint32 ttl;
 
 	DNS_AnswerType answer_type;
 	int skip_event;		///< if true, don't generate corresponding events


### PR DESCRIPTION
When there's a DNS response packet with a TTL such as 0xffffffff (4294967295), Bro decodes it as "-1.0 seconds".  The RFC indicates that the TTL in answer packets is 32 bits unsigned.  "tcpdump" has the same bug, but "wireshark" does not.

From `tcpdump`:
```
15:04:28.541023 IP (tos 0x0, ttl 63, id 25024, offset 0, flags [none], proto UDP (17), length 84)
    184.68.109.253.53 > 172.16.41.23.1081: [udp sum ok] 4226- q: A? maxttl.test. 1/0/0 maxttl.test. [-1s] A 1.1.1.1 (56)
```

From `tshark`:
```
    Answers
        maxttl.test: type A, class IN, addr 1.1.1.1
            Name: maxttl.test
            Type: A (Host Address) (1)
            Class: IN (0x0001)
            Time to live: 4294967295
                [Expert Info (Warn/Protocol): TTL can't be negative]
                    [TTL can't be negative]
                    [Severity level: Warn]
                    [Group: Protocol]
```