### PR TITLE
Add DNS "CAA" RR type and event.

### DIFF
--- a/scripts/base/protocols/dns/consts.bro
+++ b/scripts/base/protocols/dns/consts.bro
@@ -26,6 +26,7 @@ export {
 		[49] = "DHCID", [99] = "SPF", [100] = "DINFO", [101] = "UID",
 		[102] = "GID", [103] = "UNSPEC", [249] = "TKEY", [250] = "TSIG",
 		[251] = "IXFR", [252] = "AXFR", [253] = "MAILB", [254] = "MAILA",
+		[257] = "CAA",
 		[32768] = "TA", [32769] = "DLV",
 		[ANY] = "*",
 	} &default = function(n: count): string { return fmt("query-%d", n); };

--- a/src/analyzer/protocol/dns/DNS.cc
+++ b/src/analyzer/protocol/dns/DNS.cc
@@ -282,6 +282,10 @@ int DNS_Interpreter::ParseAnswer(DNS_MsgInfo* msg,
 			status = ParseRR_TXT(msg, data, len, rdlength, msg_start);
 			break;
 
+		case TYPE_CAA:
+			status = ParseRR_CAA(msg, data, len, rdlength, msg_start);
+			break;
+
 		case TYPE_NBS:
 			status = ParseRR_NBS(msg, data, len, rdlength, msg_start);
 			break;
@@ -903,6 +907,49 @@ int DNS_Interpreter::ParseRR_TXT(DNS_MsgInfo* msg,
 
 	return rdlength == 0;
 	}
+
+int DNS_Interpreter::ParseRR_CAA(DNS_MsgInfo* msg,
+				const u_char*& data, int& len, int rdlength,
+				const u_char* msg_start)
+	{
+	if ( ! dns_CAA_reply || msg->skip_event )
+		{
+		data += rdlength;
+		len -= rdlength;
+		return 1;
+		}
+
+	unsigned int flags = ExtractShort(data, len);
+	unsigned int tagLen = flags & 0xff;
+	flags = flags >> 8;
+	if ( tagLen >= (unsigned int) rdlength - 2 )
+		{
+		analyzer->Weird("DNS_CAA_char_str_past_rdlen");
+		return 0;
+		}
+	BroString* tag = new BroString(data, tagLen, 0);
+	len -= tagLen;
+	data += tagLen;
+	BroString* value = new BroString(data, rdlength-2-tagLen, 0);
+
+	val_list* vl = new val_list;
+
+	vl->append(analyzer->BuildConnVal());
+	vl->append(msg->BuildHdrVal());
+	vl->append(msg->BuildAnswerVal());
+	vl->append(new Val(flags, TYPE_COUNT));
+	vl->append(new StringVal(tag));
+	vl->append(new StringVal(value));
+
+	analyzer->ConnectionEvent(dns_CAA_reply, vl);
+
+	len -= value->Len();
+	data += value->Len();
+	rdlength -= 2 + tagLen + value->Len();
+
+	return rdlength == 0;
+	}
+
 
 void DNS_Interpreter::SendReplyOrRejectEvent(DNS_MsgInfo* msg,
 						EventHandlerPtr event,

--- a/src/analyzer/protocol/dns/DNS.h
+++ b/src/analyzer/protocol/dns/DNS.h
@@ -56,6 +56,7 @@ typedef enum {
 	TYPE_EDNS = 41,		///< OPT pseudo-RR (RFC 2671)
 	TYPE_TKEY = 249,	///< Transaction Key (RFC 2930)
 	TYPE_TSIG = 250,	///< Transaction Signature (RFC 2845)
+	TYPE_CAA = 257,		///< Certification Authority Authorization (RFC 6844)
 
 	// The following are only valid in queries.
 	TYPE_AXFR = 252,
@@ -209,6 +210,9 @@ protected:
 	int ParseRR_HINFO(DNS_MsgInfo* msg,
 				const u_char*& data, int& len, int rdlength);
 	int ParseRR_TXT(DNS_MsgInfo* msg,
+				const u_char*& data, int& len, int rdlength,
+				const u_char* msg_start);
+	int ParseRR_CAA(DNS_MsgInfo* msg,
 				const u_char*& data, int& len, int rdlength,
 				const u_char* msg_start);
 	int ParseRR_TSIG(DNS_MsgInfo* msg,

--- a/src/analyzer/protocol/dns/events.bif
+++ b/src/analyzer/protocol/dns/events.bif
@@ -378,6 +378,12 @@ event dns_MX_reply%(c: connection, msg: dns_msg, ans: dns_answer, name: string, 
 ##    dns_skip_addl dns_skip_all_addl dns_skip_all_auth dns_skip_auth
 event dns_TXT_reply%(c: connection, msg: dns_msg, ans: dns_answer, strs: string_vec%);
 
+
+## https://tools.ietf.org/html/rfc6844
+## Certification Authority Authorization
+event dns_CAA_reply%(c: connection, msg: dns_msg, ans: dns_answer, flags: count, tag: string, value: string%);
+
+
 ## Generated for DNS replies of type *SRV*. For replies with multiple answers,
 ## an individual event of the corresponding type is raised for each.
 ##


### PR DESCRIPTION
Parse DNS "CAA" (Certification Authority Authorization) DNS RR.

Example:
```
# host -a google.com. 8.8.8.8
...
;; ANSWER SECTION:
...
google.com.		21599	IN	TYPE257	\# 19 0005697373756573796D616E7465632E636F6D
```

which decodes to:
```
[ 19, "issue", "symantec.com" ]
```