### PR TITLE
Correcting wrong output for unknown data link type

### DIFF
--- a/src/iosource/PktSrc.cc
+++ b/src/iosource/PktSrc.cc
@@ -91,7 +91,7 @@ void PktSrc::Opened(const Properties& arg_props)
 		{
 		char buf[512];
 		safe_snprintf(buf, sizeof(buf),
-			 "unknown data link type 0x%x", props.link_type);
+			 "unknown data link type 0x%x", arg_props.link_type);
 		Error(buf);
 		Close();
 		return;


### PR DESCRIPTION
Unknown data link type error message printed out props.link_type instead of arg_props.link_type. It lead to the meaningless and misleading output (E.g.: 'unknown data link type 0xffffffff')

Test case:  -i nflog:7 or similar  (type is 239 (0xEF))