### PR TITLE
Add ipv6 detection to conn.log

### DIFF
--- a/scripts/base/protocols/conn/main.bro
+++ b/scripts/base/protocols/conn/main.bro
@@ -21,6 +21,8 @@ export {
 		uid:          string          &log;
 		## The connection's 4-tuple of endpoint addresses/ports.
 		id:           conn_id         &log;
+		## If the connection uses IPv6 this value will be T.
+		ipv6:         bool            &log;
 		## The transport layer protocol of the connection.
 		proto:        transport_proto &log;
 		## An identification of an application protocol being sent over
@@ -204,6 +206,7 @@ function set_conn(c: connection, eoc: bool)
 	c$conn$ts=c$start_time;
 	c$conn$uid=c$uid;
 	c$conn$id=c$id;
+	c$conn$ipv6=is_v6_addr(c$id$orig_h);
 	if ( c?$tunnel && |c$tunnel| > 0 )
 		add c$conn$tunnel_parents[c$tunnel[|c$tunnel|-1]$uid];
 	c$conn$proto=get_port_transport_proto(c$id$resp_p);


### PR DESCRIPTION
This is an additional column added to conn.log to determine if the connection is using ipv6. The address itself makes this clear, but it is much easier to grep for T/F than examining the address.