### PR TITLE
Added interpreter error for local event variables.

### DIFF
--- a/src/parse.y
+++ b/src/parse.y
@@ -1474,11 +1474,20 @@ event:
 		TOK_ID '(' opt_expr_list ')'
 			{
 			set_location(@1, @4);
-			$$ = new EventExpr($1, $3);
-			ID* id = lookup_ID($1, current_module.c_str());
 
-			if ( id && id->IsDeprecated() )
-				reporter->Warning("deprecated (%s)", id->Name());
+			ID* id = lookup_ID($1, current_module.c_str());
+			if ( id )
+				{
+				if ( ! id->IsGlobal() )
+					{
+					yyerror(fmt("local identifier \"%s\" cannot be used to reference an event", $1));
+					YYERROR;
+					}
+				if ( id->IsDeprecated() )
+					reporter->Warning("deprecated (%s)", id->Name());
+				}
+
+			$$ = new EventExpr($1, $3);
 			}
 	;
 

--- a/testing/btest/Baseline/language.event-local-var/out
+++ b/testing/btest/Baseline/language.event-local-var/out
@@ -1,0 +1,1 @@
+error in /home/jgras/devel/bro/testing/btest/.tmp/language.event-local-var/event-local-var.bro, line 15: local identifier "v" cannot be used to reference an event, at or near ")"

--- a/testing/btest/Baseline/language.event/out
+++ b/testing/btest/Baseline/language.event/out
@@ -1,6 +1,7 @@
 event statement
 event part1
 event part2
+assign event variable (6)
 schedule statement in bro_init
 schedule statement in global
 schedule statement another in bro_init

--- a/testing/btest/language/event-local-var.bro
+++ b/testing/btest/language/event-local-var.bro
@@ -1,0 +1,16 @@
+# @TEST-EXEC-FAIL: bro -b %INPUT &> out
+# @TEST-EXEC: btest-diff out
+
+
+event e1(num: count)
+	{
+	print fmt("event 1: %s", num);
+	}
+
+event bro_init()
+{
+	# Test assigning a local event variable to an event
+	local v: event(num: count);
+	v = e1;
+	schedule 1sec { v(6) };  # This should fail
+}

--- a/testing/btest/language/event.bro
+++ b/testing/btest/language/event.bro
@@ -21,7 +21,7 @@ event e3(test: string)
 
 event e4(num: count)
 	{
-	print "assign event variable";
+	print fmt("assign event variable (%s)", num);
 	}
 
 # Note: the name of this event is intentionally the same as one above
@@ -29,6 +29,8 @@ event e3(test: string)
 	{
 	print "event part2";
 	}
+
+global e5: event(num: count);
 
 event bro_init()
 {
@@ -43,9 +45,8 @@ event bro_init()
 	event e3("foo");
 
 	# Test assigning an event variable to an event
-	local e5: event(num: count);
 	e5 = e4;
-	event e5(6);  # TODO: this does not do anything
+	event e5(6);
 }
 
 # scheduling in outside of an event handler shouldn't crash.


### PR DESCRIPTION
Scheduling a local event variable resulted in a global lookup instead of evaluating the local variable. The underlying event expression is never evaluated in the local context ([``EventExpr::Eval``](https://github.com/bro/bro/blob/master/src/Expr.cc#L4658) does not get called). The [``event`` statement](https://github.com/bro/bro/blob/master/src/Stmt.cc#L1049) as well as the [``schedule`` expression](https://github.com/bro/bro/blob/master/src/Expr.cc#L4174) will result in a global lookup of the given identifier (see http://try.bro.org/#/trybro/saved/64088).

Implementing evaluation with regard to the current stack frame seems to introduce some unnecessary overhead, as there is no real use case for this. Besides this would destroy predictability like ["event handler never invoked"](https://github.com/bro/bro/blob/master/src/main.cc#L1096). To prevent misunderstandings this change will trigger an error if an event is scheduled using a local variable. Assignment of these variables is not affected and they might still be used to call bifs.