### PR TITLE
Fixed table expiration evaluation.

### DIFF
--- a/src/Val.h
+++ b/src/Val.h
@@ -862,6 +862,11 @@ protected:
 	// Calculates default value for index.  Returns 0 if none.
 	Val* Default(Val* index);
 
+	// Returns true if item expiration is defined.
+	bool ExpirationEnabled() { return expire_time != 0; }
+	// Returns the expiration time defined by create, read
+	// or write expire attribute or -1 for invalid values.
+	double GetExpireTime();
 	// Calls &expire_func and returns its return interval;
 	// takes ownership of the reference.
 	double CallExpireFunc(Val *idx);
@@ -874,8 +879,8 @@ protected:
 	TableType* table_type;
 	CompositeHash* table_hash;
 	Attributes* attrs;
-	double expire_time;
-	Expr* expire_expr;
+	Expr* expire_time;
+	Expr* expire_func;
 	TableValTimer* timer;
 	IterCookie* expire_cookie;
 	PrefixTable* subnets;

--- a/testing/btest/Baseline/language.expire-redef/output
+++ b/testing/btest/Baseline/language.expire-redef/output
@@ -1,0 +1,5 @@
+Run 0
+Run 1
+Run 2
+Expired: 0 --> some data
+Run 3

--- a/testing/btest/language/expire-redef.bro
+++ b/testing/btest/language/expire-redef.bro
@@ -1,0 +1,38 @@
+# @TEST-EXEC: btest-bg-run broproc bro %INPUT
+# @TEST-EXEC: btest-bg-wait -k 5
+# @TEST-EXEC: cat broproc/.stdout > output
+# @TEST-EXEC: btest-diff output
+
+
+@load frameworks/communication/listen
+
+const exp_val = -1sec &redef;
+
+global expired: function(tbl: table[int] of string, idx: int): interval;
+global data: table[int] of string &write_expire=exp_val &expire_func=expired;
+
+redef table_expire_interval = 1sec;
+redef exp_val = 3sec;
+
+global runs = 0;
+event do_it()
+	{
+	print fmt("Run %s", runs);
+
+	++runs;
+	if ( runs < 4 )
+		schedule 1sec { do_it() };
+	}
+
+
+function expired(tbl: table[int] of string, idx: int): interval
+	{
+	print fmt("Expired: %s --> %s", idx, tbl[idx]);
+	return 0sec;
+	}
+
+event bro_init() &priority=-10
+	{
+	data[0] = "some data";
+	schedule 1sec { do_it() };
+	}


### PR DESCRIPTION
The expiration attribute expression is now evaluated for every use. Thus 
later adjustments of the value (e.g. by redefining a const) will now take 
effect. Values less than 0 will disable expiration.