### PR TITLE
Fixed &default values ignored by input framework.

### DIFF
--- a/src/input/Manager.cc
+++ b/src/input/Manager.cc
@@ -1917,7 +1917,8 @@ RecordVal* Manager::ValueToRecordVal(const Stream* stream, const Value* const *v
 			(*position)++;
 			}
 
-		rec->Assign(i, fieldVal);
+		if ( fieldVal )
+			rec->Assign(i, fieldVal);
 		}
 
 	return rec;

--- a/testing/btest/Baseline/scripts.base.frameworks.input.default/out
+++ b/testing/btest/Baseline/scripts.base.frameworks.input.default/out
@@ -1,0 +1,8 @@
+[i=1, b=T, s=leer]
+[i=2, b=T, s=leer]
+[i=3, b=F, s=leer]
+[i=4, b=F, s=leer]
+[i=5, b=F, s=leer]
+[i=6, b=F, s=leer]
+[i=7, b=T, s=leer]
+End-of-data

--- a/testing/btest/scripts/base/frameworks/input/default.bro
+++ b/testing/btest/scripts/base/frameworks/input/default.bro
@@ -1,0 +1,48 @@
+# @TEST-EXEC: btest-bg-run bro bro -b %INPUT
+# @TEST-EXEC: btest-bg-wait 10
+# @TEST-EXEC: btest-diff out
+
+@TEST-START-FILE input.log
+#separator \x09
+#path	ssh
+#fields	i	b	
+#types	int	bool
+1	T
+2	T
+3	F
+4	F
+5	F
+6	F
+7	T
+@TEST-END-FILE
+
+redef exit_only_after_terminate = T;
+
+global outfile: file;
+
+module A;
+
+type Val: record {
+	i: int;
+	b: bool;
+	s: string &default="leer";
+};
+
+event line(description: Input::EventDescription, tpe: Input::Event, val: Val)
+	{
+	print outfile, val;
+	}
+
+event bro_init()
+	{
+	outfile = open("../out");
+	Input::add_event([$source="../input.log", $name="input", $fields=Val, $ev=line, $want_record=T]);
+	}
+
+event Input::end_of_data(name: string, source:string)
+	{
+	print outfile, "End-of-data";
+	Input::remove("input");
+	close(outfile);
+	terminate();
+	}


### PR DESCRIPTION
Reading into a record, the input framework will no longer reset a
&default value in case there is no value to read.