### PR TITLE
Update SMTP.cc

### DIFF
--- a/src/analyzer/protocol/smtp/SMTP.cc
+++ b/src/analyzer/protocol/smtp/SMTP.cc
@@ -824,6 +824,7 @@ int SMTP_Analyzer::ParseCmd(int cmd_len, const char* cmd)
 		return SMTP_CMD_X_ANONYMOUSTLS;
 
 	for ( int code = SMTP_CMD_EHLO; code < SMTP_CMD_LAST; ++code )
+		// (error) Array 'smtp_cmd_word[1]' accessed at index 22, which is out of bounds.
 		if ( ! strncasecmp(cmd, smtp_cmd_word[code - SMTP_CMD_EHLO], cmd_len) )
 			return code;
 


### PR DESCRIPTION
On line 827 array 'smtp_cmd_word[1]' is accessed at index 22, which is out of bounds. I believe this is a bug; however, I don't know how to correct it yet (and the ability to submit an Issue appears to be disabled).

Found by https://github.com/bryongloden/cppcheck