### PR TITLE
Update POP3.cc

### DIFF
--- a/src/analyzer/protocol/pop3/POP3.cc
+++ b/src/analyzer/protocol/pop3/POP3.cc
@@ -880,6 +880,7 @@ int POP3_Analyzer::ParseCmd(string cmd)
 		for ( unsigned int i = 0; i < cmd.size(); ++i )
 			cmd[i] = toupper(cmd[i]);
 
+		// (error) Array 'pop3_cmd_word[1]' accessed at index 19, which is out of bounds.
 		if ( ! cmd.compare(pop3_cmd_word[code]) )
 			return code;
 		}


### PR DESCRIPTION
This pull request is similar to #79. On line 883 array 'pop3_cmd_word[1]' is accessed at index 19, which is out of bounds. Similarly, I believe this is a bug; however, I don't know how to correct it yet (and the ability to submit an Issue still appears to be disabled).

Found by https://github.com/bryongloden/cppcheck