### PR TITLE
fix handling of embedded quotes in json logs

### DIFF
--- a/src/threading/formatters/JSON.cc
+++ b/src/threading/formatters/JSON.cc
@@ -171,8 +171,12 @@ bool JSON::Describe(ODesc* desc, Value* val, const string& name) const
 				{
 				char c = val->val.string_val.data[i];
 
-				// 2byte Unicode escape special characters.
-				if ( c < 32 || c > 126 || c == '\n' || c == '"' || c == '\'' || c == '\\' || c == '&' )
+				if ( c == '"' )
+					{
+					desc->AddRaw("\\", 1);
+					desc->AddRaw("\"", 1);
+					}
+				else if ( c < 32 || c > 126 || c == '\n' || c == '\'' || c == '\\' || c == '&' )
 					{
 					desc->AddRaw("\\u00", 4);
 					char hex[2] = {'0', '0'};


### PR DESCRIPTION
In the json log format, replacing embedded quotes with their unicode character code equivalent creates invalid JSON in Unicode-aware languages (I observed this failure while parsing the JSON in Scala). A more correct, JSON-compatible approach would be to use slashes to escape embedded quotes, i.e.

```
"key": "val\"ue"
```
