### PR TITLE
Fixed bug in Connection::InactivityTimer

### DIFF
--- a/src/Conn.cc
+++ b/src/Conn.cc
@@ -303,7 +303,7 @@ void Connection::InactivityTimer(double t)
 	// timeout once, but it's disabled now. We do nothing then.
 	if ( inactivity_timeout )
 		{
-		if ( last_time + inactivity_timeout <= t )
+		if ( last_time + inactivity_timeout >= t )
 			{
 			Event(connection_timeout, 0);
 			sessions->Remove(this);


### PR DESCRIPTION
The logic was reversed, so whenever the timer fired it would remove
a connection if it hadn't been inactive instead of removing it if it was
inactive.