### PR TITLE
Update krb-types.pac

### DIFF
--- a/src/analyzer/protocol/krb/krb-types.pac
+++ b/src/analyzer/protocol/krb/krb-types.pac
@@ -19,7 +19,7 @@ Val* GetStringFromPrincipalName(const KRB_Principal_Name* pname)
 		return bytestring_to_val(pname->data()[0][0]->encoding()->content());
 	if ( pname->data()->size() == 2 )
 		return new StringVal(fmt("%s/%s", (char *) pname->data()[0][0]->encoding()->content().begin(), (char *)pname->data()[0][1]->encoding()->content().begin()));
-	if ( pname->data()->size() == 3 )  # if the name-string has a third value, this will just append it, else this will return unkown as the principal name 
+	if ( pname->data()->size() == 3 )  # if the name-string has a third value, this will just append it, else this will return unknown as the principal name 
 		return new StringVal(fmt("%s/%s/%s", (char *) pname->data()[0][0]->encoding()->content().begin(), (char *)pname->data()[0][1]->encoding()->content().begin(), (char *)pname->data()[0][2]->encoding()->content().begin()));
 			
 	return new StringVal("unknown");

--- a/src/analyzer/protocol/krb/krb-types.pac
+++ b/src/analyzer/protocol/krb/krb-types.pac
@@ -19,7 +19,9 @@ Val* GetStringFromPrincipalName(const KRB_Principal_Name* pname)
 		return bytestring_to_val(pname->data()[0][0]->encoding()->content());
 	if ( pname->data()->size() == 2 )
 		return new StringVal(fmt("%s/%s", (char *) pname->data()[0][0]->encoding()->content().begin(), (char *)pname->data()[0][1]->encoding()->content().begin()));
-
+	if ( pname->data()->size() == 3 )  # if the name-string has a third value, this will just append it, else this will return unkown as the principal name 
+		return new StringVal(fmt("%s/%s/%s", (char *) pname->data()[0][0]->encoding()->content().begin(), (char *)pname->data()[0][1]->encoding()->content().begin(), (char *)pname->data()[0][2]->encoding()->content().begin()));
+			
 	return new StringVal("unknown");
 }
 


### PR DESCRIPTION
KerberosString formatting for principal name to be compliant with RFC 4120 section 5.2.2, which states that there can be a few components (and in practice we have seen 3, more than the 1 or 2 that is typical)