### PR TITLE
Enable "mac-logging" to flip with connections

### DIFF
--- a/scripts/policy/protocols/conn/mac-logging.bro
+++ b/scripts/policy/protocols/conn/mac-logging.bro
@@ -16,7 +16,7 @@ redef record Info += {
 # connection information is written to the log.
 event connection_state_remove(c: connection)
 	{
-	local flip = strstr(c$conn$history, "^") > 0;
+	local flip = c$conn?$history && (strstr(c$conn$history, "^") > 0);
 	
 	if ( c$orig?$l2_addr )
 		c$conn$orig_l2_addr = flip ? c$resp$l2_addr : c$orig$l2_addr;

--- a/scripts/policy/protocols/conn/mac-logging.bro
+++ b/scripts/policy/protocols/conn/mac-logging.bro
@@ -16,9 +16,11 @@ redef record Info += {
 # connection information is written to the log.
 event connection_state_remove(c: connection)
 	{
+	local flip = strstr(c$conn$history, "^") > 0;
+	
 	if ( c$orig?$l2_addr )
-		c$conn$orig_l2_addr = c$orig$l2_addr;
+		c$conn$orig_l2_addr = flip ? c$resp$l2_addr : c$orig$l2_addr;
 
 	if ( c$resp?$l2_addr )
-		c$conn$resp_l2_addr = c$resp$l2_addr;
+		c$conn$resp_l2_addr = flip ? c$orig$l2_addr : c$resp$l2_addr;
 	}


### PR DESCRIPTION
Fixes an error in the `policy/protocols/conn/mac-logging` script which occurs when the connection's directionality is flipped by Bro.  Without this modification, the MACs do not flip and get associated with the incorrect ends of the connection.