### PR TITLE
Kerberos ticket tracking

### DIFF
--- a/scripts/base/init-bare.bro
+++ b/scripts/base/init-bare.bro
@@ -3955,6 +3955,8 @@ export {
 		service_name	: string;
 		## Cipher the ticket was encrypted with
 		cipher		: count;
+		## Cipher text of the ticket
+		ciphertext  : string &optional;
 	};
 
 	type KRB::Ticket_Vector: vector of KRB::Ticket;

--- a/scripts/base/protocols/krb/main.bro
+++ b/scripts/base/protocols/krb/main.bro
@@ -164,9 +164,16 @@ event krb_tgs_request(c: connection, msg: KDC_Request) &priority=5
 		return;
 
 	local info: Info;
-	info$ts  = network_time();
-	info$uid = c$uid;
-	info$id  = c$id;
+
+	if ( !c?$krb )
+		{
+		info$ts  = network_time();
+		info$uid = c$uid;
+		info$id  = c$id;
+		}
+	else
+		info = c$krb;
+
 	info$request_type = "TGS";
 	info$service = msg$service_name;
 	if ( msg?$from ) info$from = msg$from;

--- a/scripts/policy/protocols/krb/ticket-logging.bro
+++ b/scripts/policy/protocols/krb/ticket-logging.bro
@@ -1,0 +1,43 @@
+module KRB;
+
+redef record Info += {
+	## Hash of ticket used to authorize request/transaction
+	auth_ticket: string &log &optional;
+	## Hash of ticket returned by the KDC
+	new_ticket:  string &log &optional;
+};
+
+event krb_ap_request(c: connection, ticket: KRB::Ticket, opts: KRB::AP_Options)
+	{
+	if ( c?$krb && c$krb$logged )
+		return;
+	
+	local info: Info;
+
+	if ( !c?$krb )
+		{
+		info$ts  = network_time();
+		info$uid = c$uid;
+		info$id  = c$id;
+		}
+	else
+		info = c$krb;
+
+	info$request_type = "AP"; # Will be overwritten when request is a TGS
+	if ( ticket?$ciphertext )
+		info$auth_ticket = md5_hash(ticket$ciphertext);
+
+	c$krb = info;
+	}
+
+event krb_as_response(c: connection, msg: KDC_Response)
+	{
+	if ( msg$ticket?$ciphertext )
+		c$krb$new_ticket = md5_hash(msg$ticket$ciphertext);
+	}
+
+event krb_tgs_response(c: connection, msg: KDC_Response)
+	{
+	if ( msg$ticket?$ciphertext )
+		c$krb$new_ticket = md5_hash(msg$ticket$ciphertext);
+	}

--- a/src/analyzer/protocol/krb/krb-types.pac
+++ b/src/analyzer/protocol/krb/krb-types.pac
@@ -95,6 +95,7 @@ RecordVal* proc_ticket(const KRB_Ticket* ticket)
 	rv->Assign(1, bytestring_to_val(ticket->realm()->data()->content()));
 	rv->Assign(2, GetStringFromPrincipalName(ticket->sname()));
 	rv->Assign(3, asn1_integer_to_val(ticket->enc_part()->data()->etype()->data(), TYPE_COUNT));
+	rv->Assign(4, bytestring_to_val(ticket->enc_part()->data()->ciphertext()));
 
 	return rv;
 }


### PR DESCRIPTION
These modifications enable Bro to track the creation and usage of individual Kerberos tickets.  The two primary analytics this enables is detection of "Golden Ticket" Kerberos attacks (ticket seen as "auth_ticket" but never returned from KDC as "new_ticket") and user behavior analysis through chaining together authorization chains to form distinct sessions.