### PR TITLE
Add script to log ICMP Echo traffic

### DIFF
--- a/scripts/policy/protocols/icmp/icmp-echo-logging.bro
+++ b/scripts/policy/protocols/icmp/icmp-echo-logging.bro
@@ -1,0 +1,61 @@
+module ICMP_Echo;
+
+export {
+	redef enum Log::ID += { LOG };
+
+    type Info: record {
+    	ts:           time   &log;
+    	cuid:         string &log;
+    	tx_host:      addr   &log;
+    	rx_host:      addr   &log;
+        echo_type:    string &log;
+        echo_id:      count  &log;
+        echo_seq:     count  &log;
+        echo_payload: string &log;
+    };
+}
+
+redef record connection += {
+	icmp: Info &optional;
+};
+
+event bro_init() &priority=5
+	{
+	Log::create_stream(ICMP_Echo::LOG, [$columns=Info, $path="icmp_echo"]);
+	}
+
+event icmp_echo_request(c: connection,
+	                    icmp: icmp_conn,
+	                    id: count,
+	                    seq: count,
+	                    payload: string)
+
+	{
+	local rec: ICMP_Echo::Info = [$ts=network_time(),
+	                              $cuid=c$uid,
+	                              $tx_host=c$id$orig_h,
+	                              $rx_host=c$id$resp_h,
+	                              $echo_type="request",
+	                              $echo_id=id,
+	                              $echo_seq=seq,
+	                              $echo_payload=payload];
+	Log::write(ICMP_Echo::LOG, rec);
+	}
+
+event icmp_echo_reply(c: connection,
+	                  icmp: icmp_conn,
+	                  id: count,
+	                  seq: count,
+	                  payload: string)
+
+	{
+	local rec: ICMP_Echo::Info = [$ts=network_time(),
+	                              $cuid=c$uid,
+	                              $tx_host=c$id$resp_h, # Reply is the
+	                              $rx_host=c$id$orig_h, # opposite of flow
+	                              $echo_type="reply",
+	                              $echo_id=id,
+	                              $echo_seq=seq,
+	                              $echo_payload=payload];
+	Log::write(ICMP_Echo::LOG, rec);
+	}


### PR DESCRIPTION
The id, seq, and payload of ICMP traffic can be used to distinguish various processes and operating systems from each other.  For example, GNU ping uses "ABCD..." while Windows uses slight variants depending on the version and other programs such as SolarWinds use a custom payload (e.g. SolarWinds uses "SolarWinds Echo...").

These traits can be used to whitelist expected traffic and quickly identify malicious traffic such as malware that tunnels HTTP and other protocols by through ICMP Echo request/reply payloads.