### PR TITLE
print version string to stdout on --version

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -595,7 +595,7 @@ int main(int argc, char** argv)
 			break;
 
 		case 'v':
-			fprintf(stderr, "%s version %s\n", prog, bro_version());
+			fprintf(stdout, "%s version %s\n", prog, bro_version());
 			exit(0);
 			break;
 


### PR DESCRIPTION
When running a *nix command from the prompt, and output is expected, that output should be sent to stdout, not stderr.  The --version option is such a case.  The outputted version string is not an indication of error or a diagnostic output; it is the expected output, thus should follow standard conventions and be output to stdout..