### PR TITLE
Plugin: Add hooks for log init and writing.

### DIFF
--- a/src/plugin/Manager.cc
+++ b/src/plugin/Manager.cc
@@ -712,7 +712,7 @@ void Manager::HookSetupAnalyzerTree(Connection *conn) const
 
 	if ( HavePluginForHook(META_HOOK_PRE) )
 		{
-		args.push_back(conn);
+		args.push_back(HookArgument(conn));
 		MetaHookPre(HOOK_SETUP_ANALYZER_TREE, args);
 		}
 
@@ -739,7 +739,7 @@ void Manager::HookUpdateNetworkTime(double network_time) const
 
 	if ( HavePluginForHook(META_HOOK_PRE) )
 		{
-		args.push_back(network_time);
+		args.push_back(HookArgument(network_time));
 		MetaHookPre(HOOK_UPDATE_NETWORK_TIME, args);
 		}
 
@@ -762,7 +762,7 @@ void Manager::HookBroObjDtor(void* obj) const
 
 	if ( HavePluginForHook(META_HOOK_PRE) )
 		{
-		args.push_back(obj);
+		args.push_back(HookArgument(obj));
 		MetaHookPre(HOOK_BRO_OBJ_DTOR, args);
 		}
 
@@ -777,6 +777,72 @@ void Manager::HookBroObjDtor(void* obj) const
 
 	if ( HavePluginForHook(META_HOOK_POST) )
 		MetaHookPost(HOOK_BRO_OBJ_DTOR, args, HookArgument());
+	}
+
+void Manager::HookLogInit(const std::string& writer, const std::string& instantiating_filter, bool local, bool remote, const logging::WriterBackend::WriterInfo& info, int num_fields, const threading::Field* const* fields) const
+	{
+	HookArgumentList args;
+
+	if ( HavePluginForHook(META_HOOK_PRE) )
+		{
+		args.push_back(HookArgument(writer));
+		args.push_back(HookArgument(instantiating_filter));
+		args.push_back(HookArgument(local));
+		args.push_back(HookArgument(remote));
+		args.push_back(HookArgument(&info));
+		args.push_back(HookArgument(num_fields));
+		args.push_back(HookArgument(std::make_pair(num_fields, fields)));
+		MetaHookPre(HOOK_LOG_INIT, args);
+		}
+
+	hook_list* l = hooks[HOOK_LOG_INIT];
+
+	if ( l )
+		for ( hook_list::iterator i = l->begin(); i != l->end(); ++i )
+			{
+			Plugin* p = (*i).second;
+			p->HookLogInit(writer, instantiating_filter, local, remote, info, num_fields, fields);
+			}
+
+	if ( HavePluginForHook(META_HOOK_POST) )
+		MetaHookPost(HOOK_LOG_INIT, args, HookArgument());
+	}
+
+bool Manager::HookLogWrite(const std::string& writer, const std::string& filter, const logging::WriterBackend::WriterInfo& info, int num_fields, const threading::Field* const* fields, threading::Value** vals) const
+	{
+	HookArgumentList args;
+
+	if ( HavePluginForHook(META_HOOK_PRE) )
+		{
+		args.push_back(HookArgument(writer));
+		args.push_back(HookArgument(filter));
+		args.push_back(HookArgument(&info));
+		args.push_back(HookArgument(num_fields));
+		args.push_back(HookArgument(std::make_pair(num_fields, fields)));
+		args.push_back(HookArgument(vals));
+		MetaHookPre(HOOK_LOG_WRITE, args);
+		}
+
+	hook_list* l = hooks[HOOK_LOG_WRITE];
+
+	bool result = true;
+
+	if ( l )
+		for ( hook_list::iterator i = l->begin(); i != l->end(); ++i )
+			{
+			Plugin* p = (*i).second;
+
+			if ( ! p->HookLogWrite(writer, filter, info, num_fields, fields, vals) )
+				{
+				result = false;
+				break;
+				}
+			}
+
+	if ( HavePluginForHook(META_HOOK_POST) )
+		MetaHookPost(HOOK_LOG_WRITE, args, HookArgument(result));
+
+	return result;
 	}
 
 void Manager::MetaHookPre(HookType hook, const HookArgumentList& args) const

--- a/src/plugin/Manager.h
+++ b/src/plugin/Manager.h
@@ -292,6 +292,61 @@ public:
 	void HookBroObjDtor(void* obj) const;
 
 	/**
+	 * Hook into log initialization. This method will be called when a
+	 * logging writer is created. A writer represents a single logging
+	 * filter. The method is called in the main thread, on the node that
+	 * causes a log line to be written. It will _not_ be called on the logger
+	 * node. The function will be called each for every instantiated writer.
+	 *
+	 * @param writer The name of the writer being insantiated.
+	 *
+	 * @param instantiating_filter Name of the filter causing the
+	 *        writer instantiation.
+	 *
+	 * @param local True if the filter is logging locally (writer
+	 *              thread will be located in same process).
+	 *
+	 * @param remote True if filter is logging remotely (writer thread
+	 *               will be located in different thread, typically
+	 *               in manager or logger node).
+	 *
+	 * @param info WriterBackend::WriterInfo with information about the writer.
+	 *
+	 * @param num_fields number of fields in the record being written.
+	 *
+	 * @param fields threading::Field description of the fields being logged.
+	 */
+	void HookLogInit(const std::string& writer, const std::string& instantiating_filter, bool local, bool remote, const logging::WriterBackend::WriterInfo& info, int num_fields, const threading::Field* const* fields) const;
+
+	/**
+	 * Hook into log writing. This method will be called for each log line
+	 * being written by each writer. Each writer represents a single logging
+	 * filter. The method is called in the main thread, on the node that
+	 * causes a log line to be written. It will _not_ be called on the logger
+	 * node. The function will be called each for every instantiated writer.
+	 * This function allows plugins to modify or skip logging of information.
+	 * Note - once a log line is skipped (by returning false), it will not passed
+	 * on to hooks that have not yet been called.
+	 *
+	 * @param writer The name of the writer.
+	 *
+	 * @param filter Name of the filter being written to.
+	 *
+	 * @param info WriterBackend::WriterInfo with information about the writer.
+	 *
+	 * @param num_fields number of fields in the record being written.
+	 *
+	 * @param fields threading::Field description of the fields being logged.
+	 *
+	 * @param vals threading::Values containing the values being written. Values
+	 *             can be modified in the Hook.
+	 *
+	 * @return true if log line should be written, false if log line should be
+	 *         skipped and not passed on to the writer.
+	 */
+	bool HookLogWrite(const std::string& writer, const std::string& filter, const logging::WriterBackend::WriterInfo& info, int num_fields, const threading::Field* const* fields, threading::Value** vals) const;
+
+	/**
 	 * Internal method that registers a freshly instantiated plugin with
 	 * the manager.
 	 *

--- a/src/plugin/Plugin.cc
+++ b/src/plugin/Plugin.cc
@@ -10,6 +10,8 @@
 
 #include "../Desc.h"
 #include "../Event.h"
+#include "../Conn.h"
+#include "threading/SerialTypes.h"
 
 using namespace plugin;
 
@@ -24,6 +26,8 @@ const char* plugin::hook_name(HookType h)
 		"UpdateNetworkTime",
 		"BroObjDtor",
 		"SetupAnalyzerTree",
+		"LogInit",
+		"LogWrite",
 		// MetaHooks
 		"MetaHookPre",
 		"MetaHookPost",
@@ -82,6 +86,11 @@ void HookArgument::Describe(ODesc* d) const
 			}
 		else
 			d->Add("<null>");
+		break;
+
+	case CONN:
+		if ( arg.conn )
+			arg.conn->Describe(d);
 		break;
 
 	case FUNC_RESULT:
@@ -145,6 +154,50 @@ void HookArgument::Describe(ODesc* d) const
 	case VOIDP:
 		d->Add("<void ptr>");
 		break;
+
+	case WRITER_INFO:
+		d->Add(arg.winfo->path);
+		d->Add("(");
+		d->Add(arg.winfo->network_time);
+		d->Add(",");
+		d->Add(arg.winfo->rotation_interval);
+		d->Add(",");
+		d->Add(arg.winfo->rotation_base);
+		if ( arg.winfo->config.size() > 0 )
+			{
+			bool first = true;
+			d->Add("config: {");
+			for ( auto& v: arg.winfo->config )
+				{
+				if ( ! first )
+					d->Add(", ");
+
+				d->Add(v.first);
+				d->Add(": ");
+				d->Add(v.second);
+				first = false;
+				}
+			d->Add("}");
+			}
+		d->Add(")");
+		break;
+
+		case THREAD_FIELDS:
+			d->Add("{");
+			for ( int i=0; i < tfields.first; i++ )
+				{
+				const threading::Field* f = tfields.second[i];
+
+				if ( i > 0 )
+					d->Add(", ");
+
+				d->Add(f->name);
+				d->Add(" (");
+				d->Add(f->TypeName());
+				d->Add(")");
+				}
+			d->Add("}");
+			break;
 	}
 	}
 
@@ -317,6 +370,15 @@ void Plugin::HookSetupAnalyzerTree(Connection *conn)
 
 void Plugin::HookBroObjDtor(void* obj)
 	{
+	}
+
+void Plugin::HookLogInit(const std::string& writer, const std::string& instantiating_filter, bool local, bool remote, const logging::WriterBackend::WriterInfo& info, int num_fields, const threading::Field* const* fields)
+	{
+	}
+
+bool Plugin::HookLogWrite(const std::string& writer, const std::string& filter, const logging::WriterBackend::WriterInfo& info, int num_fields, const threading::Field* const* fields, threading::Value** vals)
+	{
+	return true;
 	}
 
 void Plugin::MetaHookPre(HookType hook, const HookArgumentList& args)

--- a/src/plugin/Plugin.h
+++ b/src/plugin/Plugin.h
@@ -11,15 +11,20 @@
 #include "analyzer/Component.h"
 #include "file_analysis/Component.h"
 #include "iosource/Component.h"
+#include "logging/WriterBackend.h"
 
 // We allow to override this externally for testing purposes.
 #ifndef BRO_PLUGIN_API_VERSION
-#define BRO_PLUGIN_API_VERSION 4
+#define BRO_PLUGIN_API_VERSION 5
 #endif
 
 class ODesc;
 class Func;
 class Event;
+
+namespace threading {
+struct Field;
+}
 
 namespace plugin  {
 
@@ -39,7 +44,9 @@ enum HookType {
 	HOOK_DRAIN_EVENTS,		//< Activates Plugin::HookDrainEvents()
 	HOOK_UPDATE_NETWORK_TIME,	//< Activates Plugin::HookUpdateNetworkTime.
 	HOOK_BRO_OBJ_DTOR,		//< Activates Plugin::HookBroObjDtor.
-	HOOK_SETUP_ANALYZER_TREE,	//< Activates Plugin::HookSetupAnalyzerTree
+	HOOK_SETUP_ANALYZER_TREE,	//< Activates Plugin::HookAddToAnalyzerTree
+	HOOK_LOG_INIT,			//< Activates Plugin::HookLogInit
+	HOOK_LOG_WRITE,			//< Activates Plugin::HookLogWrite
 
 	// Meta hooks.
 	META_HOOK_PRE,			//< Activates Plugin::MetaHookPre().
@@ -158,7 +165,8 @@ public:
 	 * Type of the argument.
 	 */
 	enum Type {
-		BOOL, DOUBLE, EVENT, FRAME, FUNC, FUNC_RESULT, INT, STRING, VAL, VAL_LIST, VOID, VOIDP
+		BOOL, DOUBLE, EVENT, FRAME, FUNC, FUNC_RESULT, INT, STRING, VAL, VAL_LIST, VOID, VOIDP,
+		WRITER_INFO, CONN, THREAD_FIELDS
 	};
 
 	/**
@@ -169,57 +177,72 @@ public:
 	/**
 	 * Constructor with a boolean argument.
 	 */
-	HookArgument(bool a)	{ type = BOOL; arg.bool_ = a; }
+	explicit HookArgument(bool a)	{ type = BOOL; arg.bool_ = a; }
 
 	/**
 	 * Constructor with a double argument.
 	 */
-	HookArgument(double a)	{ type = DOUBLE; arg.double_ = a; }
+	explicit HookArgument(double a)	{ type = DOUBLE; arg.double_ = a; }
 
 	/**
 	 * Constructor with an event argument.
 	 */
-	HookArgument(const Event* a)	{ type = EVENT; arg.event = a; }
+	explicit HookArgument(const Event* a)	{ type = EVENT; arg.event = a; }
+
+	/**
+	 * Constructor with an connection argument.
+	 */
+	explicit HookArgument(const Connection* c)	{ type = CONN; arg.conn = c; }
 
 	/**
 	 * Constructor with a function argument.
 	 */
-	HookArgument(const Func* a)	{ type = FUNC; arg.func = a; }
+	explicit HookArgument(const Func* a)	{ type = FUNC; arg.func = a; }
 
 	/**
 	 * Constructor with an integer  argument.
 	 */
-	HookArgument(int a)	{ type = INT; arg.int_ = a; }
+	explicit HookArgument(int a)	{ type = INT; arg.int_ = a; }
 
 	/**
 	 * Constructor with a string argument.
 	 */
-	HookArgument(const std::string& a)	{ type = STRING; arg_string = a; }
+	explicit HookArgument(const std::string& a)	{ type = STRING; arg_string = a; }
 
 	/**
 	 * Constructor with a Bro value argument.
 	 */
-	HookArgument(const Val* a)	{ type = VAL; arg.val = a; }
+	explicit HookArgument(const Val* a)	{ type = VAL; arg.val = a; }
 
 	/**
 	 * Constructor with a list of Bro values argument.
 	 */
-	HookArgument(const val_list* a)	{ type = VAL_LIST; arg.vals = a; }
+	explicit HookArgument(const val_list* a)	{ type = VAL_LIST; arg.vals = a; }
 
 	/**
 	 * Constructor with a void pointer argument.
 	 */
-	HookArgument(void* p)	{ type = VOIDP; arg.voidp = p; }
+	explicit HookArgument(void* p)	{ type = VOIDP; arg.voidp = p; }
 
 	/**
 	 * Constructor with a function result argument.
 	 */
-	HookArgument(std::pair<bool, Val*> fresult)	{ type = FUNC_RESULT; func_result = fresult; }
+	explicit HookArgument(std::pair<bool, Val*> fresult)	{ type = FUNC_RESULT; func_result = fresult; }
 
 	/**
 	 * Constructor with a Frame argument.
 	 */
-	HookArgument(Frame* f)	{ type = FRAME; arg.frame = f; }
+	explicit HookArgument(Frame* f)	{ type = FRAME; arg.frame = f; }
+
+	/**
+	 * Constructor with a WriterInfo argument.
+	 */
+	explicit HookArgument(const logging::WriterBackend::WriterInfo* i)	{ type = WRITER_INFO; arg.winfo = i; }
+
+	/**
+	 * Constructor with a threading field argument.
+	 */
+	explicit HookArgument(const std::pair<int, const threading::Field* const*> fpair)	{ type = THREAD_FIELDS; tfields = fpair; }
 
 	/**
 	 * Returns the value for a boolen argument. The argument's type must
@@ -238,6 +261,12 @@ public:
 	 * match accordingly.
 	 */
 	const Event* AsEvent() const	{ assert(type == EVENT); return arg.event; }
+
+	/**
+	 * Returns the value for an connection argument. The argument's type must
+	 * match accordingly.
+	 */
+	const Connection* AsConnection() const	{ assert(type == CONN); return arg.conn; }
 
 	/**
 	 * Returns the value for a function argument. The argument's type must
@@ -276,6 +305,18 @@ public:
 	const Frame* AsFrame() const { assert(type == FRAME); return arg.frame; }
 
 	/**
+	 * Returns the value for a logging WriterInfo argument.  The argument's type must
+	 * match accordingly.
+	 */
+	const logging::WriterBackend::WriterInfo* AsWriterInfo() const { assert(type == WRITER_INFO); return arg.winfo; }
+
+	/**
+	 * Returns the value for a threading fields argument.  The argument's type must
+	 * match accordingly.
+	 */
+	const std::pair<int, const threading::Field* const*> AsThreadFields() const { assert(type == THREAD_FIELDS); return tfields; }
+
+	/**
 	 * Returns the value for a list of Bro values argument. The argument's type must
 	 * match accordingly.
 	 */
@@ -305,16 +346,19 @@ private:
 		bool bool_;
 		double double_;
 		const Event* event;
+		const Connection* conn;
 		const Func* func;
 		const Frame* frame;
 		int int_;
 		const Val* val;
 		const val_list* vals;
 		const void* voidp;
+		const logging::WriterBackend::WriterInfo* winfo;
 	} arg;
 
 	// Outside union because these have dtors.
 	std::pair<bool, Val*> func_result;
+	std::pair<int, const threading::Field* const*> tfields;
 	std::string arg_string;
 };
 
@@ -662,6 +706,61 @@ protected:
 	 * dereferenced.
 	 */
 	virtual void HookBroObjDtor(void* obj);
+
+	/**
+	 * Hook into log initialization. This method will be called when a
+	 * logging writer is created. A writer represents a single logging
+	 * filter. The method is called in the main thread, on the node that
+	 * causes a log line to be written. It will _not_ be called on the logger
+	 * node. The function will be called each for every instantiated writer.
+	 *
+	 * @param writer The name of the writer being insantiated.
+	 *
+	 * @param instantiating_filter Name of the filter causing the
+	 *        writer instantiation.
+	 *
+	 * @param local True if the filter is logging locally (writer
+	 *              thread will be located in same process).
+	 *
+	 * @param remote True if filter is logging remotely (writer thread
+	 *               will be located in different thread, typically
+	 *               in manager or logger node).
+	 *
+	 * @param info WriterBackend::WriterInfo with information about the writer.
+	 *
+	 * @param num_fields number of fields in the record being written.
+	 *
+	 * @param fields threading::Field description of the fields being logged.
+	 */
+	virtual void HookLogInit(const std::string& writer, const std::string& instantiating_filter, bool local, bool remote, const logging::WriterBackend::WriterInfo& info, int num_fields, const threading::Field* const* fields);
+
+	/**
+	 * Hook into log writing. This method will be called for each log line
+	 * being written by each writer. Each writer represents a single logging
+	 * filter. The method is called in the main thread, on the node that
+	 * causes a log line to be written. It will _not_ be called on the logger
+	 * node. The function will be called each for every instantiated writer.
+	 * This function allows plugins to modify or skip logging of information.
+	 * Note - once a log line is skipped (by returning false), it will not passed
+	 * on to hooks that have not yet been called.
+	 *
+	 * @param writer The name of the writer.
+	 *
+	 * @param filter Name of the filter being written to.
+	 *
+	 * @param info WriterBackend::WriterInfo with information about the writer.
+	 *
+	 * @param num_fields number of fields in the record being written.
+	 *
+	 * @param fields threading::Field description of the fields being logged.
+	 *
+	 * @param vals threading::Values containing the values being written. Values
+	 *             can be modified in the Hook.
+	 *
+	 * @return true if log line should be written, false if log line should be
+	 *         skipped and not passed on to the writer.
+	 */
+	virtual bool HookLogWrite(const std::string& writer, const std::string& filter, const logging::WriterBackend::WriterInfo& info, int num_fields, const threading::Field* const* fields, threading::Value** vals);
 
 	// Meta hooks.
 

--- a/src/threading/Formatter.cc
+++ b/src/threading/Formatter.cc
@@ -22,7 +22,7 @@ Formatter::~Formatter()
 	{
 	}
 
-string Formatter::Render(const threading::Value::addr_t& addr) const
+string Formatter::Render(const threading::Value::addr_t& addr)
 	{
 	if ( addr.family == IPv4 )
 		{
@@ -90,7 +90,7 @@ threading::Value::addr_t Formatter::ParseAddr(const string &s) const
 	return val;
 	}
 
-string Formatter::Render(const threading::Value::subnet_t& subnet) const
+string Formatter::Render(const threading::Value::subnet_t& subnet)
 	{
 	char l[16];
 
@@ -104,7 +104,7 @@ string Formatter::Render(const threading::Value::subnet_t& subnet) const
 	return s;
 	}
 
-string Formatter::Render(double d) const
+string Formatter::Render(double d)
 	{
 	char buf[256];
 	modp_dtoa(d, buf, 6);

--- a/src/threading/Formatter.h
+++ b/src/threading/Formatter.h
@@ -87,7 +87,7 @@ public:
 	 *
 	 * @return An ASCII representation of the address.
 	 */
-	string Render(const threading::Value::addr_t& addr) const;
+	static string Render(const threading::Value::addr_t& addr);
 
 	/**
 	 * Convert an subnet value into a string.
@@ -98,7 +98,7 @@ public:
 	 *
 	 * @return An ASCII representation of the subnet.
 	 */
-	string Render(const threading::Value::subnet_t& subnet) const;
+	static string Render(const threading::Value::subnet_t& subnet);
 
 	/**
 	 * Convert a double into a string. This renders the double with Bro's
@@ -110,7 +110,7 @@ public:
 	 *
 	 * @return An ASCII representation of the double.
 	 */
-	string Render(double d) const;
+	static string Render(double d);
 
 	/**
 	 * Convert a string into a TransportProto. The string must be one of

--- a/testing/btest/Baseline/plugins.hooks/output
+++ b/testing/btest/Baseline/plugins.hooks/output
@@ -247,7 +247,7 @@
 0.000000   MetaHookPost  CallFunction(Log::__create_stream, <frame>, (Weird::LOG, [columns=<no value description>, ev=Weird::log_weird, path=weird])) -> <no result>
 0.000000   MetaHookPost  CallFunction(Log::__create_stream, <frame>, (X509::LOG, [columns=<no value description>, ev=X509::log_x509, path=x509])) -> <no result>
 0.000000   MetaHookPost  CallFunction(Log::__create_stream, <frame>, (mysql::LOG, [columns=<no value description>, ev=MySQL::log_mysql, path=mysql])) -> <no result>
-0.000000   MetaHookPost  CallFunction(Log::__write, <frame>, (PacketFilter::LOG, [ts=1488302456.440387, node=bro, filter=ip or not ip, init=T, success=T])) -> <no result>
+0.000000   MetaHookPost  CallFunction(Log::__write, <frame>, (PacketFilter::LOG, [ts=1493067689.952434, node=bro, filter=ip or not ip, init=T, success=T])) -> <no result>
 0.000000   MetaHookPost  CallFunction(Log::add_default_filter, <frame>, (Cluster::LOG)) -> <no result>
 0.000000   MetaHookPost  CallFunction(Log::add_default_filter, <frame>, (Communication::LOG)) -> <no result>
 0.000000   MetaHookPost  CallFunction(Log::add_default_filter, <frame>, (Conn::LOG)) -> <no result>
@@ -377,7 +377,7 @@
 0.000000   MetaHookPost  CallFunction(Log::create_stream, <frame>, (Weird::LOG, [columns=<no value description>, ev=Weird::log_weird, path=weird])) -> <no result>
 0.000000   MetaHookPost  CallFunction(Log::create_stream, <frame>, (X509::LOG, [columns=<no value description>, ev=X509::log_x509, path=x509])) -> <no result>
 0.000000   MetaHookPost  CallFunction(Log::create_stream, <frame>, (mysql::LOG, [columns=<no value description>, ev=MySQL::log_mysql, path=mysql])) -> <no result>
-0.000000   MetaHookPost  CallFunction(Log::write, <frame>, (PacketFilter::LOG, [ts=1488302456.440387, node=bro, filter=ip or not ip, init=T, success=T])) -> <no result>
+0.000000   MetaHookPost  CallFunction(Log::write, <frame>, (PacketFilter::LOG, [ts=1493067689.952434, node=bro, filter=ip or not ip, init=T, success=T])) -> <no result>
 0.000000   MetaHookPost  CallFunction(NetControl::check_plugins, <frame>, ()) -> <no result>
 0.000000   MetaHookPost  CallFunction(NetControl::init, <null>, ()) -> <no result>
 0.000000   MetaHookPost  CallFunction(Notice::want_pp, <frame>, ()) -> <no result>
@@ -712,6 +712,8 @@
 0.000000   MetaHookPost  LoadFile(base<...>/weird) -> -1
 0.000000   MetaHookPost  LoadFile(base<...>/x509) -> -1
 0.000000   MetaHookPost  LoadFile(base<...>/xmpp) -> -1
+0.000000   MetaHookPost  LogInit(Log::WRITER_ASCII, default, true, true, packet_filter(0.0,0.0,0.0), 5, {ts (time), node (string), filter (string), init (bool), success (bool)}) -> <void>
+0.000000   MetaHookPost  LogWrite(Log::WRITER_ASCII, default, packet_filter(0.0,0.0,0.0), 5, {ts (time), node (string), filter (string), init (bool), success (bool)}, <void ptr>) -> true
 0.000000   MetaHookPost  QueueEvent(NetControl::init()) -> false
 0.000000   MetaHookPost  QueueEvent(bro_init()) -> false
 0.000000   MetaHookPost  QueueEvent(filter_change_tracking()) -> false
@@ -964,7 +966,7 @@
 0.000000   MetaHookPre   CallFunction(Log::__create_stream, <frame>, (Weird::LOG, [columns=<no value description>, ev=Weird::log_weird, path=weird]))
 0.000000   MetaHookPre   CallFunction(Log::__create_stream, <frame>, (X509::LOG, [columns=<no value description>, ev=X509::log_x509, path=x509]))
 0.000000   MetaHookPre   CallFunction(Log::__create_stream, <frame>, (mysql::LOG, [columns=<no value description>, ev=MySQL::log_mysql, path=mysql]))
-0.000000   MetaHookPre   CallFunction(Log::__write, <frame>, (PacketFilter::LOG, [ts=1488302456.440387, node=bro, filter=ip or not ip, init=T, success=T]))
+0.000000   MetaHookPre   CallFunction(Log::__write, <frame>, (PacketFilter::LOG, [ts=1493067689.952434, node=bro, filter=ip or not ip, init=T, success=T]))
 0.000000   MetaHookPre   CallFunction(Log::add_default_filter, <frame>, (Cluster::LOG))
 0.000000   MetaHookPre   CallFunction(Log::add_default_filter, <frame>, (Communication::LOG))
 0.000000   MetaHookPre   CallFunction(Log::add_default_filter, <frame>, (Conn::LOG))
@@ -1094,7 +1096,7 @@
 0.000000   MetaHookPre   CallFunction(Log::create_stream, <frame>, (Weird::LOG, [columns=<no value description>, ev=Weird::log_weird, path=weird]))
 0.000000   MetaHookPre   CallFunction(Log::create_stream, <frame>, (X509::LOG, [columns=<no value description>, ev=X509::log_x509, path=x509]))
 0.000000   MetaHookPre   CallFunction(Log::create_stream, <frame>, (mysql::LOG, [columns=<no value description>, ev=MySQL::log_mysql, path=mysql]))
-0.000000   MetaHookPre   CallFunction(Log::write, <frame>, (PacketFilter::LOG, [ts=1488302456.440387, node=bro, filter=ip or not ip, init=T, success=T]))
+0.000000   MetaHookPre   CallFunction(Log::write, <frame>, (PacketFilter::LOG, [ts=1493067689.952434, node=bro, filter=ip or not ip, init=T, success=T]))
 0.000000   MetaHookPre   CallFunction(NetControl::check_plugins, <frame>, ())
 0.000000   MetaHookPre   CallFunction(NetControl::init, <null>, ())
 0.000000   MetaHookPre   CallFunction(Notice::want_pp, <frame>, ())
@@ -1429,6 +1431,8 @@
 0.000000   MetaHookPre   LoadFile(base<...>/weird)
 0.000000   MetaHookPre   LoadFile(base<...>/x509)
 0.000000   MetaHookPre   LoadFile(base<...>/xmpp)
+0.000000   MetaHookPre   LogInit(Log::WRITER_ASCII, default, true, true, packet_filter(0.0,0.0,0.0), 5, {ts (time), node (string), filter (string), init (bool), success (bool)})
+0.000000   MetaHookPre   LogWrite(Log::WRITER_ASCII, default, packet_filter(0.0,0.0,0.0), 5, {ts (time), node (string), filter (string), init (bool), success (bool)}, <void ptr>)
 0.000000   MetaHookPre   QueueEvent(NetControl::init())
 0.000000   MetaHookPre   QueueEvent(bro_init())
 0.000000   MetaHookPre   QueueEvent(filter_change_tracking())
@@ -1680,7 +1684,7 @@
 0.000000 | HookCallFunction Log::__create_stream(Weird::LOG, [columns=<no value description>, ev=Weird::log_weird, path=weird])
 0.000000 | HookCallFunction Log::__create_stream(X509::LOG, [columns=<no value description>, ev=X509::log_x509, path=x509])
 0.000000 | HookCallFunction Log::__create_stream(mysql::LOG, [columns=<no value description>, ev=MySQL::log_mysql, path=mysql])
-0.000000 | HookCallFunction Log::__write(PacketFilter::LOG, [ts=1488302456.440387, node=bro, filter=ip or not ip, init=T, success=T])
+0.000000 | HookCallFunction Log::__write(PacketFilter::LOG, [ts=1493067689.952434, node=bro, filter=ip or not ip, init=T, success=T])
 0.000000 | HookCallFunction Log::add_default_filter(Cluster::LOG)
 0.000000 | HookCallFunction Log::add_default_filter(Communication::LOG)
 0.000000 | HookCallFunction Log::add_default_filter(Conn::LOG)
@@ -1810,7 +1814,7 @@
 0.000000 | HookCallFunction Log::create_stream(Weird::LOG, [columns=<no value description>, ev=Weird::log_weird, path=weird])
 0.000000 | HookCallFunction Log::create_stream(X509::LOG, [columns=<no value description>, ev=X509::log_x509, path=x509])
 0.000000 | HookCallFunction Log::create_stream(mysql::LOG, [columns=<no value description>, ev=MySQL::log_mysql, path=mysql])
-0.000000 | HookCallFunction Log::write(PacketFilter::LOG, [ts=1488302456.440387, node=bro, filter=ip or not ip, init=T, success=T])
+0.000000 | HookCallFunction Log::write(PacketFilter::LOG, [ts=1493067689.952434, node=bro, filter=ip or not ip, init=T, success=T])
 0.000000 | HookCallFunction NetControl::check_plugins()
 0.000000 | HookCallFunction NetControl::init()
 0.000000 | HookCallFunction Notice::want_pp()
@@ -1851,6 +1855,8 @@
 0.000000 | HookLoadFile  <...>/bro
 0.000000 | HookLoadFile  base<...>/bif
 0.000000 | HookLoadFile  base<...>/bro
+0.000000 | HookLogInit   packet_filter 1/1 {ts (time), node (string), filter (string), init (bool), success (bool)}
+0.000000 | HookLogWrite  packet_filter [ts=1493067689.952434, node=bro, filter=ip or not ip, init=T, success=T]
 0.000000 | HookQueueEvent NetControl::init()
 0.000000 | HookQueueEvent bro_init()
 0.000000 | HookQueueEvent filter_change_tracking()
@@ -1865,6 +1871,7 @@
 1362692526.869344   MetaHookPost  QueueEvent(ChecksumOffloading::check()) -> false
 1362692526.869344   MetaHookPost  QueueEvent(filter_change_tracking()) -> false
 1362692526.869344   MetaHookPost  QueueEvent(new_connection([id=[orig_h=141.142.228.5, orig_p=59856<...>/tcp], orig=[size=0, state=0, num_pkts=0, num_bytes_ip=0, flow_label=0, l2_addr=c8:bc:c8:96:d2:a0], resp=[size=0, state=0, num_pkts=0, num_bytes_ip=0, flow_label=0, l2_addr=00:10:db:88:d2:ef], start_time=1362692526.869344, duration=0.0, service={}, history=, uid=CHhAvVGS1DHFjwGM9, tunnel=<uninitialized>, vlan=<uninitialized>, inner_vlan=<uninitialized>, dpd=<uninitialized>, conn=<uninitialized>, extract_orig=F, extract_resp=F, thresholds=<uninitialized>, dce_rpc=<uninitialized>, dce_rpc_state=<uninitialized>, dce_rpc_backing=<uninitialized>, dhcp=<uninitialized>, dnp3=<uninitialized>, dns=<uninitialized>, dns_state=<uninitialized>, ftp=<uninitialized>, ftp_data_reuse=F, ssl=<uninitialized>, http=<uninitialized>, http_state=<uninitialized>, irc=<uninitialized>, krb=<uninitialized>, modbus=<uninitialized>, mysql=<uninitialized>, ntlm=<uninitialized>, radius=<uninitialized>, rdp=<uninitialized>, rfb=<uninitialized>, sip=<uninitialized>, sip_state=<uninitialized>, snmp=<uninitialized>, smtp=<uninitialized>, smtp_state=<uninitialized>, socks=<uninitialized>, ssh=<uninitialized>, syslog=<uninitialized>])) -> false
+1362692526.869344   MetaHookPost  SetupAnalyzerTree(1362692526.869344(1362692526.869344) TCP 141.142.228.5:59856 -> 192.150.187.43:80) -> <void>
 1362692526.869344   MetaHookPost  UpdateNetworkTime(1362692526.869344) -> <void>
 1362692526.869344   MetaHookPre   BroObjDtor(<void ptr>)
 1362692526.869344   MetaHookPre   CallFunction(ChecksumOffloading::check, <null>, ())
@@ -1877,6 +1884,7 @@
 1362692526.869344   MetaHookPre   QueueEvent(ChecksumOffloading::check())
 1362692526.869344   MetaHookPre   QueueEvent(filter_change_tracking())
 1362692526.869344   MetaHookPre   QueueEvent(new_connection([id=[orig_h=141.142.228.5, orig_p=59856<...>/tcp], orig=[size=0, state=0, num_pkts=0, num_bytes_ip=0, flow_label=0, l2_addr=c8:bc:c8:96:d2:a0], resp=[size=0, state=0, num_pkts=0, num_bytes_ip=0, flow_label=0, l2_addr=00:10:db:88:d2:ef], start_time=1362692526.869344, duration=0.0, service={}, history=, uid=CHhAvVGS1DHFjwGM9, tunnel=<uninitialized>, vlan=<uninitialized>, inner_vlan=<uninitialized>, dpd=<uninitialized>, conn=<uninitialized>, extract_orig=F, extract_resp=F, thresholds=<uninitialized>, dce_rpc=<uninitialized>, dce_rpc_state=<uninitialized>, dce_rpc_backing=<uninitialized>, dhcp=<uninitialized>, dnp3=<uninitialized>, dns=<uninitialized>, dns_state=<uninitialized>, ftp=<uninitialized>, ftp_data_reuse=F, ssl=<uninitialized>, http=<uninitialized>, http_state=<uninitialized>, irc=<uninitialized>, krb=<uninitialized>, modbus=<uninitialized>, mysql=<uninitialized>, ntlm=<uninitialized>, radius=<uninitialized>, rdp=<uninitialized>, rfb=<uninitialized>, sip=<uninitialized>, sip_state=<uninitialized>, snmp=<uninitialized>, smtp=<uninitialized>, smtp_state=<uninitialized>, socks=<uninitialized>, ssh=<uninitialized>, syslog=<uninitialized>]))
+1362692526.869344   MetaHookPre   SetupAnalyzerTree(1362692526.869344(1362692526.869344) TCP 141.142.228.5:59856 -> 192.150.187.43:80)
 1362692526.869344   MetaHookPre   UpdateNetworkTime(1362692526.869344)
 1362692526.869344  | HookBroObjDtor
 1362692526.869344  | HookUpdateNetworkTime 1362692526.869344
@@ -1890,6 +1898,7 @@
 1362692526.869344 | HookQueueEvent ChecksumOffloading::check()
 1362692526.869344 | HookQueueEvent filter_change_tracking()
 1362692526.869344 | HookQueueEvent new_connection([id=[orig_h=141.142.228.5, orig_p=59856<...>/tcp], orig=[size=0, state=0, num_pkts=0, num_bytes_ip=0, flow_label=0, l2_addr=c8:bc:c8:96:d2:a0], resp=[size=0, state=0, num_pkts=0, num_bytes_ip=0, flow_label=0, l2_addr=00:10:db:88:d2:ef], start_time=1362692526.869344, duration=0.0, service={}, history=, uid=CHhAvVGS1DHFjwGM9, tunnel=<uninitialized>, vlan=<uninitialized>, inner_vlan=<uninitialized>, dpd=<uninitialized>, conn=<uninitialized>, extract_orig=F, extract_resp=F, thresholds=<uninitialized>, dce_rpc=<uninitialized>, dce_rpc_state=<uninitialized>, dce_rpc_backing=<uninitialized>, dhcp=<uninitialized>, dnp3=<uninitialized>, dns=<uninitialized>, dns_state=<uninitialized>, ftp=<uninitialized>, ftp_data_reuse=F, ssl=<uninitialized>, http=<uninitialized>, http_state=<uninitialized>, irc=<uninitialized>, krb=<uninitialized>, modbus=<uninitialized>, mysql=<uninitialized>, ntlm=<uninitialized>, radius=<uninitialized>, rdp=<uninitialized>, rfb=<uninitialized>, sip=<uninitialized>, sip_state=<uninitialized>, snmp=<uninitialized>, smtp=<uninitialized>, smtp_state=<uninitialized>, socks=<uninitialized>, ssh=<uninitialized>, syslog=<uninitialized>])
+1362692526.869344 | HookSetupAnalyzerTree 1362692526.869344(1362692526.869344) TCP 141.142.228.5:59856 -> 192.150.187.43:80
 1362692526.869344 | RequestObjDtor ChecksumOffloading::check()
 1362692526.939084   MetaHookPost  CallFunction(NetControl::catch_release_seen, <frame>, (141.142.228.5)) -> <no result>
 1362692526.939084   MetaHookPost  CallFunction(addr_to_subnet, <frame>, (141.142.228.5)) -> <no result>
@@ -2204,6 +2213,10 @@
 1362692527.009775   MetaHookPost  CallFunction(id_string, <frame>, ([orig_h=141.142.228.5, orig_p=59856<...>/tcp])) -> <no result>
 1362692527.009775   MetaHookPost  CallFunction(set_file_handle, <frame>, (Analyzer::ANALYZER_HTTP1362692526.869344F11141.142.228.5:59856 > 192.150.187.43:80)) -> <no result>
 1362692527.009775   MetaHookPost  DrainEvents() -> <void>
+1362692527.009775   MetaHookPost  LogInit(Log::WRITER_ASCII, default, true, true, files(1362692527.009775,0.0,0.0), 25, {ts (time), fuid (string), tx_hosts (set[addr]), rx_hosts (set[addr]), conn_uids (set[string]), source (string), depth (count), analyzers (set[string]), mime_type (string), filename (string), duration (interval), local_orig (bool), is_orig (bool), seen_bytes (count), total_bytes (count), missing_bytes (count), overflow_bytes (count), timedout (bool), parent_fuid (string), md5 (string), sha1 (string), sha256 (string), extracted (string), extracted_cutoff (bool), extracted_size (count)}) -> <void>
+1362692527.009775   MetaHookPost  LogInit(Log::WRITER_ASCII, default, true, true, http(1362692527.009775,0.0,0.0), 29, {ts (time), uid (string), id.orig_h (addr), id.orig_p (port), id.resp_h (addr), id.resp_p (port), trans_depth (count), method (string), host (string), uri (string), referrer (string), version (string), user_agent (string), request_body_len (count), response_body_len (count), status_code (count), status_msg (string), info_code (count), info_msg (string), tags (set[enum]), username (string), password (string), proxied (set[string]), orig_fuids (vector[string]), orig_filenames (vector[string]), orig_mime_types (vector[string]), resp_fuids (vector[string]), resp_filenames (vector[string]), resp_mime_types (vector[string])}) -> <void>
+1362692527.009775   MetaHookPost  LogWrite(Log::WRITER_ASCII, default, files(1362692527.009775,0.0,0.0), 25, {ts (time), fuid (string), tx_hosts (set[addr]), rx_hosts (set[addr]), conn_uids (set[string]), source (string), depth (count), analyzers (set[string]), mime_type (string), filename (string), duration (interval), local_orig (bool), is_orig (bool), seen_bytes (count), total_bytes (count), missing_bytes (count), overflow_bytes (count), timedout (bool), parent_fuid (string), md5 (string), sha1 (string), sha256 (string), extracted (string), extracted_cutoff (bool), extracted_size (count)}, <void ptr>) -> true
+1362692527.009775   MetaHookPost  LogWrite(Log::WRITER_ASCII, default, http(1362692527.009775,0.0,0.0), 29, {ts (time), uid (string), id.orig_h (addr), id.orig_p (port), id.resp_h (addr), id.resp_p (port), trans_depth (count), method (string), host (string), uri (string), referrer (string), version (string), user_agent (string), request_body_len (count), response_body_len (count), status_code (count), status_msg (string), info_code (count), info_msg (string), tags (set[enum]), username (string), password (string), proxied (set[string]), orig_fuids (vector[string]), orig_filenames (vector[string]), orig_mime_types (vector[string]), resp_fuids (vector[string]), resp_filenames (vector[string]), resp_mime_types (vector[string])}, <void ptr>) -> true
 1362692527.009775   MetaHookPost  QueueEvent(file_sniff([id=FakNcS1Jfe01uljb3, parent_id=<uninitialized>, source=HTTP, is_orig=F, conns={[[orig_h=141.142.228.5, orig_p=59856<...>/plain]]])) -> false
 1362692527.009775   MetaHookPost  QueueEvent(file_state_remove([id=FakNcS1Jfe01uljb3, parent_id=<uninitialized>, source=HTTP, is_orig=F, conns={[[orig_h=141.142.228.5, orig_p=59856<...>/plain], current_entity=[filename=<uninitialized>], orig_mime_depth=1, resp_mime_depth=1], irc=<uninitialized>, pe=<uninitialized>, u2_events=<uninitialized>])) -> false
 1362692527.009775   MetaHookPost  QueueEvent(get_file_handle(Analyzer::ANALYZER_HTTP, [id=[orig_h=141.142.228.5, orig_p=59856<...>/plain], current_entity=[filename=<uninitialized>], orig_mime_depth=1, resp_mime_depth=1]}, current_request=1, current_response=1, trans_depth=1], irc=<uninitialized>, krb=<uninitialized>, modbus=<uninitialized>, mysql=<uninitialized>, ntlm=<uninitialized>, radius=<uninitialized>, rdp=<uninitialized>, rfb=<uninitialized>, sip=<uninitialized>, sip_state=<uninitialized>, snmp=<uninitialized>, smtp=<uninitialized>, smtp_state=<uninitialized>, socks=<uninitialized>, ssh=<uninitialized>, syslog=<uninitialized>], F)) -> false
@@ -2229,6 +2242,10 @@
 1362692527.009775   MetaHookPre   CallFunction(id_string, <frame>, ([orig_h=141.142.228.5, orig_p=59856<...>/tcp]))
 1362692527.009775   MetaHookPre   CallFunction(set_file_handle, <frame>, (Analyzer::ANALYZER_HTTP1362692526.869344F11141.142.228.5:59856 > 192.150.187.43:80))
 1362692527.009775   MetaHookPre   DrainEvents()
+1362692527.009775   MetaHookPre   LogInit(Log::WRITER_ASCII, default, true, true, files(1362692527.009775,0.0,0.0), 25, {ts (time), fuid (string), tx_hosts (set[addr]), rx_hosts (set[addr]), conn_uids (set[string]), source (string), depth (count), analyzers (set[string]), mime_type (string), filename (string), duration (interval), local_orig (bool), is_orig (bool), seen_bytes (count), total_bytes (count), missing_bytes (count), overflow_bytes (count), timedout (bool), parent_fuid (string), md5 (string), sha1 (string), sha256 (string), extracted (string), extracted_cutoff (bool), extracted_size (count)})
+1362692527.009775   MetaHookPre   LogInit(Log::WRITER_ASCII, default, true, true, http(1362692527.009775,0.0,0.0), 29, {ts (time), uid (string), id.orig_h (addr), id.orig_p (port), id.resp_h (addr), id.resp_p (port), trans_depth (count), method (string), host (string), uri (string), referrer (string), version (string), user_agent (string), request_body_len (count), response_body_len (count), status_code (count), status_msg (string), info_code (count), info_msg (string), tags (set[enum]), username (string), password (string), proxied (set[string]), orig_fuids (vector[string]), orig_filenames (vector[string]), orig_mime_types (vector[string]), resp_fuids (vector[string]), resp_filenames (vector[string]), resp_mime_types (vector[string])})
+1362692527.009775   MetaHookPre   LogWrite(Log::WRITER_ASCII, default, files(1362692527.009775,0.0,0.0), 25, {ts (time), fuid (string), tx_hosts (set[addr]), rx_hosts (set[addr]), conn_uids (set[string]), source (string), depth (count), analyzers (set[string]), mime_type (string), filename (string), duration (interval), local_orig (bool), is_orig (bool), seen_bytes (count), total_bytes (count), missing_bytes (count), overflow_bytes (count), timedout (bool), parent_fuid (string), md5 (string), sha1 (string), sha256 (string), extracted (string), extracted_cutoff (bool), extracted_size (count)}, <void ptr>)
+1362692527.009775   MetaHookPre   LogWrite(Log::WRITER_ASCII, default, http(1362692527.009775,0.0,0.0), 29, {ts (time), uid (string), id.orig_h (addr), id.orig_p (port), id.resp_h (addr), id.resp_p (port), trans_depth (count), method (string), host (string), uri (string), referrer (string), version (string), user_agent (string), request_body_len (count), response_body_len (count), status_code (count), status_msg (string), info_code (count), info_msg (string), tags (set[enum]), username (string), password (string), proxied (set[string]), orig_fuids (vector[string]), orig_filenames (vector[string]), orig_mime_types (vector[string]), resp_fuids (vector[string]), resp_filenames (vector[string]), resp_mime_types (vector[string])}, <void ptr>)
 1362692527.009775   MetaHookPre   QueueEvent(file_sniff([id=FakNcS1Jfe01uljb3, parent_id=<uninitialized>, source=HTTP, is_orig=F, conns={[[orig_h=141.142.228.5, orig_p=59856<...>/plain]]]))
 1362692527.009775   MetaHookPre   QueueEvent(file_state_remove([id=FakNcS1Jfe01uljb3, parent_id=<uninitialized>, source=HTTP, is_orig=F, conns={[[orig_h=141.142.228.5, orig_p=59856<...>/plain], current_entity=[filename=<uninitialized>], orig_mime_depth=1, resp_mime_depth=1], irc=<uninitialized>, pe=<uninitialized>, u2_events=<uninitialized>]))
 1362692527.009775   MetaHookPre   QueueEvent(get_file_handle(Analyzer::ANALYZER_HTTP, [id=[orig_h=141.142.228.5, orig_p=59856<...>/plain], current_entity=[filename=<uninitialized>], orig_mime_depth=1, resp_mime_depth=1]}, current_request=1, current_response=1, trans_depth=1], irc=<uninitialized>, krb=<uninitialized>, modbus=<uninitialized>, mysql=<uninitialized>, ntlm=<uninitialized>, radius=<uninitialized>, rdp=<uninitialized>, rfb=<uninitialized>, sip=<uninitialized>, sip_state=<uninitialized>, snmp=<uninitialized>, smtp=<uninitialized>, smtp_state=<uninitialized>, socks=<uninitialized>, ssh=<uninitialized>, syslog=<uninitialized>], F))
@@ -2255,6 +2272,10 @@
 1362692527.009775 | HookCallFunction id_string([orig_h=141.142.228.5, orig_p=59856<...>/tcp])
 1362692527.009775 | HookCallFunction set_file_handle(Analyzer::ANALYZER_HTTP1362692526.869344F11141.142.228.5:59856 > 192.150.187.43:80)
 1362692527.009775 | HookDrainEvents
+1362692527.009775 | HookLogInit   files 1/1 {ts (time), fuid (string), tx_hosts (set[addr]), rx_hosts (set[addr]), conn_uids (set[string]), source (string), depth (count), analyzers (set[string]), mime_type (string), filename (string), duration (interval), local_orig (bool), is_orig (bool), seen_bytes (count), total_bytes (count), missing_bytes (count), overflow_bytes (count), timedout (bool), parent_fuid (string), md5 (string), sha1 (string), sha256 (string), extracted (string), extracted_cutoff (bool), extracted_size (count)}
+1362692527.009775 | HookLogInit   http 1/1 {ts (time), uid (string), id.orig_h (addr), id.orig_p (port), id.resp_h (addr), id.resp_p (port), trans_depth (count), method (string), host (string), uri (string), referrer (string), version (string), user_agent (string), request_body_len (count), response_body_len (count), status_code (count), status_msg (string), info_code (count), info_msg (string), tags (set[enum]), username (string), password (string), proxied (set[string]), orig_fuids (vector[string]), orig_filenames (vector[string]), orig_mime_types (vector[string]), resp_fuids (vector[string]), resp_filenames (vector[string]), resp_mime_types (vector[string])}
+1362692527.009775 | HookLogWrite  files [ts=1362692527.009512, fuid=FakNcS1Jfe01uljb3, tx_hosts=192.150.187.43, rx_hosts=141.142.228.5, conn_uids=CHhAvVGS1DHFjwGM9, source=HTTP, depth=0, analyzers=, mime_type=text/plain, filename=<uninitialized>, duration=0.000263, local_orig=<uninitialized>, is_orig=F, seen_bytes=4705, total_bytes=4705, missing_bytes=0, overflow_bytes=0, timedout=F, parent_fuid=<uninitialized>, md5=<uninitialized>, sha1=<uninitialized>, sha256=<uninitialized>, extracted=<uninitialized>, extracted_cutoff=<uninitialized>, extracted_size=<uninitialized>]
+1362692527.009775 | HookLogWrite  http [ts=1362692526.939527, uid=CHhAvVGS1DHFjwGM9, id.orig_h=141.142.228.5, id.orig_p=59856, id.resp_h=192.150.187.43, id.resp_p=80, trans_depth=1, method=GET, host=bro.org, uri=<...>/plain]
 1362692527.009775 | HookQueueEvent file_sniff([id=FakNcS1Jfe01uljb3, parent_id=<uninitialized>, source=HTTP, is_orig=F, conns={[[orig_h=141.142.228.5, orig_p=59856<...>/plain]]])
 1362692527.009775 | HookQueueEvent file_state_remove([id=FakNcS1Jfe01uljb3, parent_id=<uninitialized>, source=HTTP, is_orig=F, conns={[[orig_h=141.142.228.5, orig_p=59856<...>/plain], current_entity=[filename=<uninitialized>], orig_mime_depth=1, resp_mime_depth=1], irc=<uninitialized>, pe=<uninitialized>, u2_events=<uninitialized>])
 1362692527.009775 | HookQueueEvent get_file_handle(Analyzer::ANALYZER_HTTP, [id=[orig_h=141.142.228.5, orig_p=59856<...>/plain], current_entity=[filename=<uninitialized>], orig_mime_depth=1, resp_mime_depth=1]}, current_request=1, current_response=1, trans_depth=1], irc=<uninitialized>, krb=<uninitialized>, modbus=<uninitialized>, mysql=<uninitialized>, ntlm=<uninitialized>, radius=<uninitialized>, rdp=<uninitialized>, rfb=<uninitialized>, sip=<uninitialized>, sip_state=<uninitialized>, snmp=<uninitialized>, smtp=<uninitialized>, smtp_state=<uninitialized>, socks=<uninitialized>, ssh=<uninitialized>, syslog=<uninitialized>], F)
@@ -2309,6 +2330,8 @@
 1362692527.080972   MetaHookPost  CallFunction(sub_bytes, <frame>, (HTTP, 0, 1)) -> <no result>
 1362692527.080972   MetaHookPost  CallFunction(to_lower, <frame>, (HTTP)) -> <no result>
 1362692527.080972   MetaHookPost  DrainEvents() -> <void>
+1362692527.080972   MetaHookPost  LogInit(Log::WRITER_ASCII, default, true, true, conn(1362692527.080972,0.0,0.0), 21, {ts (time), uid (string), id.orig_h (addr), id.orig_p (port), id.resp_h (addr), id.resp_p (port), proto (enum), service (string), duration (interval), orig_bytes (count), resp_bytes (count), conn_state (string), local_orig (bool), local_resp (bool), missed_bytes (count), history (string), orig_pkts (count), orig_ip_bytes (count), resp_pkts (count), resp_ip_bytes (count), tunnel_parents (set[string])}) -> <void>
+1362692527.080972   MetaHookPost  LogWrite(Log::WRITER_ASCII, default, conn(1362692527.080972,0.0,0.0), 21, {ts (time), uid (string), id.orig_h (addr), id.orig_p (port), id.resp_h (addr), id.resp_p (port), proto (enum), service (string), duration (interval), orig_bytes (count), resp_bytes (count), conn_state (string), local_orig (bool), local_resp (bool), missed_bytes (count), history (string), orig_pkts (count), orig_ip_bytes (count), resp_pkts (count), resp_ip_bytes (count), tunnel_parents (set[string])}, <void ptr>) -> true
 1362692527.080972   MetaHookPost  QueueEvent(ChecksumOffloading::check()) -> false
 1362692527.080972   MetaHookPost  QueueEvent(bro_done()) -> false
 1362692527.080972   MetaHookPost  QueueEvent(connection_state_remove([id=[orig_h=141.142.228.5, orig_p=59856<...>/plain], current_entity=<uninitialized>, orig_mime_depth=1, resp_mime_depth=1], http_state=[pending={}, current_request=1, current_response=1, trans_depth=1], irc=<uninitialized>, krb=<uninitialized>, modbus=<uninitialized>, mysql=<uninitialized>, ntlm=<uninitialized>, radius=<uninitialized>, rdp=<uninitialized>, rfb=<uninitialized>, sip=<uninitialized>, sip_state=<uninitialized>, snmp=<uninitialized>, smtp=<uninitialized>, smtp_state=<uninitialized>, socks=<uninitialized>, ssh=<uninitialized>, syslog=<uninitialized>])) -> false
@@ -2340,6 +2363,8 @@
 1362692527.080972   MetaHookPre   CallFunction(sub_bytes, <frame>, (HTTP, 0, 1))
 1362692527.080972   MetaHookPre   CallFunction(to_lower, <frame>, (HTTP))
 1362692527.080972   MetaHookPre   DrainEvents()
+1362692527.080972   MetaHookPre   LogInit(Log::WRITER_ASCII, default, true, true, conn(1362692527.080972,0.0,0.0), 21, {ts (time), uid (string), id.orig_h (addr), id.orig_p (port), id.resp_h (addr), id.resp_p (port), proto (enum), service (string), duration (interval), orig_bytes (count), resp_bytes (count), conn_state (string), local_orig (bool), local_resp (bool), missed_bytes (count), history (string), orig_pkts (count), orig_ip_bytes (count), resp_pkts (count), resp_ip_bytes (count), tunnel_parents (set[string])})
+1362692527.080972   MetaHookPre   LogWrite(Log::WRITER_ASCII, default, conn(1362692527.080972,0.0,0.0), 21, {ts (time), uid (string), id.orig_h (addr), id.orig_p (port), id.resp_h (addr), id.resp_p (port), proto (enum), service (string), duration (interval), orig_bytes (count), resp_bytes (count), conn_state (string), local_orig (bool), local_resp (bool), missed_bytes (count), history (string), orig_pkts (count), orig_ip_bytes (count), resp_pkts (count), resp_ip_bytes (count), tunnel_parents (set[string])}, <void ptr>)
 1362692527.080972   MetaHookPre   QueueEvent(ChecksumOffloading::check())
 1362692527.080972   MetaHookPre   QueueEvent(bro_done())
 1362692527.080972   MetaHookPre   QueueEvent(connection_state_remove([id=[orig_h=141.142.228.5, orig_p=59856<...>/plain], current_entity=<uninitialized>, orig_mime_depth=1, resp_mime_depth=1], http_state=[pending={}, current_request=1, current_response=1, trans_depth=1], irc=<uninitialized>, krb=<uninitialized>, modbus=<uninitialized>, mysql=<uninitialized>, ntlm=<uninitialized>, radius=<uninitialized>, rdp=<uninitialized>, rfb=<uninitialized>, sip=<uninitialized>, sip_state=<uninitialized>, snmp=<uninitialized>, smtp=<uninitialized>, smtp_state=<uninitialized>, socks=<uninitialized>, ssh=<uninitialized>, syslog=<uninitialized>]))
@@ -2372,6 +2397,8 @@
 1362692527.080972 | HookCallFunction sub_bytes(HTTP, 0, 1)
 1362692527.080972 | HookCallFunction to_lower(HTTP)
 1362692527.080972 | HookDrainEvents
+1362692527.080972 | HookLogInit   conn 1/1 {ts (time), uid (string), id.orig_h (addr), id.orig_p (port), id.resp_h (addr), id.resp_p (port), proto (enum), service (string), duration (interval), orig_bytes (count), resp_bytes (count), conn_state (string), local_orig (bool), local_resp (bool), missed_bytes (count), history (string), orig_pkts (count), orig_ip_bytes (count), resp_pkts (count), resp_ip_bytes (count), tunnel_parents (set[string])}
+1362692527.080972 | HookLogWrite  conn [ts=1362692526.869344, uid=CHhAvVGS1DHFjwGM9, id.orig_h=141.142.228.5, id.orig_p=59856, id.resp_h=192.150.187.43, id.resp_p=80, proto=tcp, service=http, duration=0.211484, orig_bytes=136, resp_bytes=5007, conn_state=SF, local_orig=<uninitialized>, local_resp=<uninitialized>, missed_bytes=0, history=ShADadFf, orig_pkts=7, orig_ip_bytes=512, resp_pkts=7, resp_ip_bytes=5379, tunnel_parents=]
 1362692527.080972 | HookQueueEvent ChecksumOffloading::check()
 1362692527.080972 | HookQueueEvent bro_done()
 1362692527.080972 | HookQueueEvent connection_state_remove([id=[orig_h=141.142.228.5, orig_p=59856<...>/plain], current_entity=<uninitialized>, orig_mime_depth=1, resp_mime_depth=1], http_state=[pending={}, current_request=1, current_response=1, trans_depth=1], irc=<uninitialized>, krb=<uninitialized>, modbus=<uninitialized>, mysql=<uninitialized>, ntlm=<uninitialized>, radius=<uninitialized>, rdp=<uninitialized>, rfb=<uninitialized>, sip=<uninitialized>, sip_state=<uninitialized>, snmp=<uninitialized>, smtp=<uninitialized>, smtp_state=<uninitialized>, socks=<uninitialized>, ssh=<uninitialized>, syslog=<uninitialized>])

--- a/testing/btest/Baseline/plugins.logging-hooks/output
+++ b/testing/btest/Baseline/plugins.logging-hooks/output
@@ -1,0 +1,1 @@
+1488216470.960453 | HookLogInit   ssh 1/1 {b (bool), i (int), e (enum), c (count), p (port), sn (subnet), a (addr), d (double), t (time), iv (interval), s (string), sc (set[count]), ss (set[string]), se (set[string]), vc (vector[count]), ve (vector[string]), f (func)}

--- a/testing/btest/Baseline/plugins.logging-hooks/ssh.log
+++ b/testing/btest/Baseline/plugins.logging-hooks/ssh.log
@@ -1,0 +1,11 @@
+#separator \x09
+#set_separator	,
+#empty_field	EMPTY
+#unset_field	-
+#path	ssh
+#open	2017-02-27-17-27-50
+#fields	b	i	e	c	p	sn	a	d	t	iv	s	sc	ss	se	vc	ve	f
+#types	bool	int	enum	count	port	subnet	addr	double	time	interval	string	set[count]	set[string]	set[string]	vector[count]	vector[string]	func
+F	-2	SSH::LOG	21	123	10.0.0.0/24	1.2.3.4	3.14	1488216470.960453	100.000000	hurz	2,4,1,3	BB,AA,CC	EMPTY	10,20,30	EMPTY	SSH::foo\x0a{ \x0aif (0 < SSH::i) \x0a\x09return (Foo);\x0aelse\x0a\x09return (Bar);\x0a\x0a}
+T	-	SSH::LOG	21	123	10.0.0.0/24	1.2.3.4	3.14	1488216470.960453	100.000000	hurz	2,4,1,3	BB,AA,CC	EMPTY	10,20,30	EMPTY	SSH::foo\x0a{ \x0aif (0 < SSH::i) \x0a\x09return (Foo);\x0aelse\x0a\x09return (Bar);\x0a\x0a}
+#close	2017-02-27-17-27-50

--- a/testing/btest/plugins/hooks-plugin/src/Plugin.h
+++ b/testing/btest/plugins/hooks-plugin/src/Plugin.h
@@ -10,17 +10,22 @@ namespace Demo_Hooks {
 class Plugin : public ::plugin::Plugin
 {
 protected:
-	virtual int HookLoadFile(const std::string& file, const std::string& ext);
-	virtual std::pair<bool, Val*> HookCallFunction(const Func* func, Frame* frame, val_list* args);
-	virtual bool HookQueueEvent(Event* event);
-	virtual void HookDrainEvents();
-	virtual void HookUpdateNetworkTime(double network_time);
-	virtual void HookBroObjDtor(void* obj);
-	virtual void MetaHookPre(HookType hook, const HookArgumentList& args);
-	virtual void MetaHookPost(HookType hook, const HookArgumentList& args, HookArgument result);
+	int HookLoadFile(const std::string& file, const std::string& ext) override;
+	std::pair<bool, Val*> HookCallFunction(const Func* func, Frame* frame, val_list* args) override;
+	bool HookQueueEvent(Event* event) override;
+	void HookDrainEvents() override;
+	void HookUpdateNetworkTime(double network_time) override;
+	void HookBroObjDtor(void* obj) override;
+	void HookLogInit(const std::string& writer, const std::string& instantiating_filter, bool local, bool remote, const logging::WriterBackend::WriterInfo& info, int num_fields, const threading::Field* const* fields) override;
+	bool HookLogWrite(const std::string& writer, const std::string& filter, const logging::WriterBackend::WriterInfo& info, int num_fields, const threading::Field* const* fields, threading::Value** vals) override;
+	void HookSetupAnalyzerTree(Connection *conn) override;
+	void MetaHookPre(HookType hook, const HookArgumentList& args) override;
+	void MetaHookPost(HookType hook, const HookArgumentList& args, HookArgument result) override;
+
+	void RenderVal(const threading::Value* val, ODesc &d) const;
 
 	// Overridden from plugin::Plugin.
-	virtual plugin::Configuration Configure();
+	plugin::Configuration Configure() override;
 };
 
 extern Plugin plugin;

--- a/testing/btest/plugins/logging-hooks-plugin/src/Plugin.cc
+++ b/testing/btest/plugins/logging-hooks-plugin/src/Plugin.cc
@@ -1,0 +1,60 @@
+
+#include "Plugin.h"
+
+#include <Func.h>
+#include <Event.h>
+#include <Conn.h>
+#include <threading/Formatter.h>
+
+namespace plugin { namespace Log_Hooks { Plugin plugin; } }
+
+using namespace plugin::Log_Hooks;
+
+plugin::Configuration Plugin::Configure()
+	{
+	round = 0;
+	EnableHook(HOOK_LOG_INIT);
+	EnableHook(HOOK_LOG_WRITE);
+
+	plugin::Configuration config;
+	config.name = "Log::Hooks";
+	config.description = "Exercises Log hooks";
+	config.version.major = 1;
+	config.version.minor = 0;
+	return config;
+	}
+
+void Plugin::HookLogInit(const std::string& writer, const std::string& instantiating_filter, bool local, bool remote, const logging::WriterBackend::WriterInfo& info, int num_fields, const threading::Field* const* fields)
+	{
+	ODesc d;
+
+	d.Add("{");
+	for ( int i=0; i < num_fields; i++ )
+		{
+		const threading::Field* f = fields[i];
+
+		if ( i > 0 )
+			d.Add(", ");
+
+		d.Add(f->name);
+		d.Add(" (");
+		d.Add(f->TypeName());
+		d.Add(")");
+		}
+	d.Add("}");
+
+	fprintf(stderr, "%.6f %-15s %s %d/%d %s\n", network_time, "| HookLogInit", info.path, local, remote, d.Description());
+	}
+
+bool Plugin::HookLogWrite(const std::string& writer, const std::string& filter, const logging::WriterBackend::WriterInfo& info, int num_fields, const threading::Field* const* fields, threading::Value** vals)
+	{
+	round++;
+	if ( round == 1 ) // do not output line
+		return false;
+	else if ( round == 2 )
+		vals[0]->val.int_val = 0;
+	else if ( round == 3 )
+		vals[1]->present = false;
+
+	return true;
+	}

--- a/testing/btest/plugins/logging-hooks-plugin/src/Plugin.h
+++ b/testing/btest/plugins/logging-hooks-plugin/src/Plugin.h
@@ -1,0 +1,28 @@
+
+#ifndef BRO_PLUGIN_Log_Hooks
+#define BRO_PLUGIN_Log_Hooks
+
+#include <plugin/Plugin.h>
+
+namespace plugin {
+namespace Log_Hooks {
+
+class Plugin : public ::plugin::Plugin
+{
+protected:
+	void HookLogInit(const std::string& writer, const std::string& instantiating_filter, bool local, bool remote, const logging::WriterBackend::WriterInfo& info, int num_fields, const threading::Field* const* fields) override;
+	bool HookLogWrite(const std::string& writer, const std::string& filter, const logging::WriterBackend::WriterInfo& info, int num_fields, const threading::Field* const* fields, threading::Value** vals) override;
+
+	// Overridden from plugin::Plugin.
+	plugin::Configuration Configure() override;
+
+private:
+	int round;
+};
+
+extern Plugin plugin;
+
+}
+}
+
+#endif

--- a/testing/btest/plugins/logging-hooks.bro
+++ b/testing/btest/plugins/logging-hooks.bro
@@ -1,0 +1,72 @@
+# @TEST-EXEC: ${DIST}/aux/bro-aux/plugin-support/init-plugin -u . Log Hooks
+# @TEST-EXEC: cp -r %DIR/logging-hooks-plugin/* .
+# @TEST-EXEC: ./configure --bro-dist=${DIST} && make
+# @TEST-EXEC: BRO_PLUGIN_ACTIVATE="Log::Hooks" BRO_PLUGIN_PATH=`pwd` bro -b %INPUT 2>&1 | $SCRIPTS/diff-remove-abspath | sort | uniq  >output
+# @TEST-EXEC: btest-diff output
+# @TEST-EXEC: btest-diff ssh.log
+
+redef LogAscii::empty_field = "EMPTY";
+
+module SSH;
+
+export {
+	redef enum Log::ID += { LOG };
+
+	type Log: record {
+		b: bool;
+		i: int &optional;
+		e: Log::ID;
+		c: count;
+		p: port;
+		sn: subnet;
+		a: addr;
+		d: double;
+		t: time;
+		iv: interval;
+		s: string;
+		sc: set[count];
+		ss: set[string];
+		se: set[string];
+		vc: vector of count;
+		ve: vector of string;
+		f: function(i: count) : string;
+	} &log;
+}
+
+function foo(i : count) : string
+	{
+	if ( i > 0 )
+		return "Foo";
+	else
+		return "Bar";
+	}
+
+event bro_init()
+{
+	Log::create_stream(SSH::LOG, [$columns=Log]);
+
+	local empty_set: set[string];
+	local empty_vector: vector of string;
+
+	local i = 0;
+	while ( ++i < 4 )
+		Log::write(SSH::LOG, [
+			$b=T,
+			$i=-i,
+			$e=SSH::LOG,
+			$c=21,
+			$p=123/tcp,
+			$sn=10.0.0.1/24,
+			$a=1.2.3.4,
+			$d=3.14,
+			$t=network_time(),
+			$iv=100secs,
+			$s="hurz",
+			$sc=set(1,2,3,4),
+			$ss=set("AA", "BB", "CC"),
+			$se=empty_set,
+			$vc=vector(10, 20, 30),
+			$ve=empty_vector,
+			$f=foo
+			]);
+}


### PR DESCRIPTION
This branch adds two new hooks, giving the ability to hook into log initialization and log writing.

The two hooks being added are:

void HookLogInit(const std::string& writer, const std::string& instantiating_filter, bool local, bool remote, const logging::WriterBackend::WriterInfo& info, int num_fields, const threading::Field* const* fields);

which is called when a writer is being instantiated and contains
information about the fields being logged, as well as

bool HookLogWrite(const std::string& writer, const std::string& filter, const logging::WriterBackend::WriterInfo& info, int num_fields, const threading::Field* const* fields, threading::Value** vals);

which is called for each log line being written by each writer. It
contains all the data being written. The data can be changed in the
function call and lines can be prevented from being written.

Both hooks are called on the node that performs the write. The hooks are called in the context of the main thread.

This commit also fixes a few small problems with plugin hooks itself,
and extends the tests that were already there, besides introducing tests
for the added functionality.

Please attribute this change to "Corelight".