### PR TITLE
padding comes before flags

### DIFF
--- a/src/analyzer/protocol/krb/krb-protocol.pac
+++ b/src/analyzer/protocol/krb/krb-protocol.pac
@@ -136,7 +136,7 @@ type KRB_AP_REQ(is_orig: bool) = record {
 
 type KRB_AP_Options = record {
 	meta 	: SequenceElement(false);
-		: padding[meta.meta.length - 4];
+		: padding[1];
 	flags	: uint32;
 } &let {
 	reserved	: bool = (flags & 0x80000000) > 0;

--- a/src/analyzer/protocol/krb/krb-protocol.pac
+++ b/src/analyzer/protocol/krb/krb-protocol.pac
@@ -136,8 +136,8 @@ type KRB_AP_REQ(is_orig: bool) = record {
 
 type KRB_AP_Options = record {
 	meta 	: SequenceElement(false);
+		: padding[meta.meta.length - 4];
 	flags	: uint32;
-		: padding[1];
 } &let {
 	reserved	: bool = (flags & 0x80000000) > 0;
 	use_session_key	: bool = (flags & 0x40000000) > 0;


### PR DESCRIPTION
I am not able to find it in RFC, but all of the pcaps I came across  (https://wiki.wireshark.org/SampleCaptures) contain padding in-front of flags. Length should be calculated from asn1 metadata.