### PR TITLE
Fix segmentation fault on eval condition with no return value.

### DIFF
--- a/src/RuleCondition.cc
+++ b/src/RuleCondition.cc
@@ -175,8 +175,13 @@ bool RuleConditionEval::DoMatch(Rule* rule, RuleEndpointState* state,
 	try
 		{
 		Val* val = id->ID_Val()->AsFunc()->Call(&args);
-		result = val->AsBool();
-		Unref(val);
+		if ( val )
+			{
+			result = val->AsBool();
+			Unref(val);
+			}
+		else
+			result = false;
 		}
 
 	catch ( InterpreterException& e )

--- a/testing/btest/Baseline/signatures.eval-condition-no-return-value/.stderr
+++ b/testing/btest/Baseline/signatures.eval-condition-no-return-value/.stderr
@@ -1,0 +1,3 @@
+1329843162.083353 warning: non-void function returns without a value: mark_conn
+1329843164.920456 warning: non-void function returns without a value: mark_conn
+1329843200.079930 warning: non-void function returns without a value: mark_conn

--- a/testing/btest/Baseline/signatures.eval-condition-no-return-value/.stdout
+++ b/testing/btest/Baseline/signatures.eval-condition-no-return-value/.stdout
@@ -1,0 +1,3 @@
+Called
+Called
+Called

--- a/testing/btest/signatures/eval-condition-no-return-value.bro
+++ b/testing/btest/signatures/eval-condition-no-return-value.bro
@@ -1,0 +1,20 @@
+# @TEST-EXEC: bro -r $TRACES/ftp/ipv4.trace %INPUT
+# @TEST-EXEC: btest-diff .stdout
+# @TEST-EXEC: btest-diff .stderr
+
+@load-sigs blah.sig
+
+@TEST-START-FILE blah.sig
+signature blah
+	{
+	ip-proto == tcp
+	src-port == 21
+	payload /.*/
+	eval mark_conn
+	}
+@TEST-END-FILE
+
+function mark_conn(state: signature_state, data: string): bool
+	{
+	print "Called";
+	}


### PR DESCRIPTION
Signatures using an eval-condition that had no return value caused a
segmentation fault. This fix just returns false in this case, as it is
done for an interpreter error.

Please attribute this change to "Corelight".