### PR TITLE
Add -B scripts flag to allow debug output of script load order.

### DIFF
--- a/src/DebugLogger.cc
+++ b/src/DebugLogger.cc
@@ -19,7 +19,8 @@ DebugLogger::Stream DebugLogger::streams[NUM_DBGS] = {
 	{ "logging", 0, false }, {"input", 0, false },
 	{ "threading", 0, false }, { "file_analysis", 0, false },
 	{ "plugins", 0, false }, { "broxygen", 0, false },
-	{ "pktio", 0, false }, { "broker", 0, false }
+	{ "pktio", 0, false }, { "broker", 0, false },
+	{ "scripts", 0, false}
 };
 
 DebugLogger::DebugLogger()

--- a/src/DebugLogger.h
+++ b/src/DebugLogger.h
@@ -33,6 +33,7 @@ enum DebugStream {
 	DBG_BROXYGEN,	// Broxygen
 	DBG_PKTIO,	// Packet sources and dumpers.
 	DBG_BROKER,	// Broker communication
+	DBG_SCRIPTS,	// Script initialization
 
 	NUM_DBGS // Has to be last
 };

--- a/src/scan.l
+++ b/src/scan.l
@@ -636,6 +636,8 @@ static int load_files(const char* orig_file)
 
 	broxygen_mgr->Script(file_path);
 
+	DBG_LOG(DBG_SCRIPTS, "Loading %s", file_path.c_str());
+
 	// "orig_file", could be an alias for yytext, which is ephemeral
 	//  and will be zapped after the yy_switch_to_buffer() below.
 	yy_switch_to_buffer(yy_create_buffer(f, YY_BUF_SIZE));


### PR DESCRIPTION
This patch adds a "scripts" option to -B, when Bro is enabled with
--enable-debug. This option will output information about the scripts
that are loaded to debug.log, showing their exact load order.

Please attribute this change to "Corelight".