### PR TITLE
Minor Bro docs tweaks for correctness and readability

### DIFF
--- a/doc/_static/broxygen.css
+++ b/doc/_static/broxygen.css
@@ -152,12 +152,10 @@ sup, sub {
 
 pre, code  {
 	white-space: pre;
-    overflow: auto;
-    margin-left: 2em;
-    margin-right: 2em;
-    margin-top: .5em;
-    margin-bottom: 1.5em;
-    word-wrap: normal;
+	overflow: auto;
+	margin-left: 0.25em;
+	margin-right: 0.25em;
+	word-wrap: normal;
 }
 
 pre, code, tt {

--- a/doc/_templates/layout.html
+++ b/doc/_templates/layout.html
@@ -10,7 +10,7 @@
 {% endblock %}
 
 {% block header %}
-<iframe src="//www.bro.org/frames/header-no-logo.html" width="100%" height="100px" frameborder="0" marginheight="0" scrolling="no" marginwidth="0">
+<iframe src="https://www.bro.org/frames/header-no-logo.html" width="100%" height="100px" frameborder="0" marginheight="0" scrolling="no" marginwidth="0">
 </iframe>
 {% endblock %}
 
@@ -108,6 +108,6 @@
 {% endblock %}
 
 {% block footer %}
-<iframe src="//www.bro.org/frames/footer.html" width="100%" height="420px" frameborder="0" marginheight="0" scrolling="no" marginwidth="0">
+<iframe src="https://www.bro.org/frames/footer.html" width="100%" height="420px" frameborder="0" marginheight="0" scrolling="no" marginwidth="0">
 </iframe>
 {% endblock %}


### PR DESCRIPTION
- The protocol seemed to be missing from two frame inclusions, throwing an
  error message when viewing the page locally. Add "https:".

- Reduce whitespace around inline code blocks, where 2em seems really
  large.