### PR TITLE
SSH Protocol Violation Fix

### DIFF
--- a/src/analyzer/protocol/ssh/ssh-analyzer.pac
+++ b/src/analyzer/protocol/ssh/ssh-analyzer.pac
@@ -173,6 +173,18 @@ refine flow SSH_Flow += {
 		connection()->bro_analyzer()->ProtocolConfirmation();
 		return true;
 		%}
+
+	function get_kex_length(v: int, packet_length: uint32): int
+		%{
+		switch (v) {
+			case SSH1:
+				return packet_length + 4 + 8 -(packet_length%8);
+			case SSH2:
+				return packet_length + 4;
+			default:
+				return 1; //currently causes the rest of the packet to dump
+		}
+		%}
 };
 
 refine typeattr SSH_Version += &let {

--- a/src/analyzer/protocol/ssh/ssh-protocol.pac
+++ b/src/analyzer/protocol/ssh/ssh-protocol.pac
@@ -22,21 +22,23 @@ type SSH_Version(is_orig: bool) = record {
 	update_version : bool = $context.connection.update_version(version, is_orig);
 };
 
-type SSH_Key_Exchange(is_orig: bool) = case $context.connection.get_version() of {
-	SSH1 -> ssh1_msg : SSH1_Key_Exchange(is_orig);
-	SSH2 -> ssh2_msg : SSH2_Key_Exchange(is_orig);
-};
+type SSH_Key_Exchange(is_orig: bool) = record {
+	packet_length: uint32;
+	key_ex: case $context.connection.get_version() of {
+		SSH1 -> ssh1_msg : SSH1_Key_Exchange(is_orig, packet_length);
+		SSH2 -> ssh2_msg : SSH2_Key_Exchange(is_orig, packet_length);
+	};
+} &length = $context.flow.get_kex_length($context.connection.get_version(), packet_length);
 
 # SSH1 constructs
 #################
 
-type SSH1_Key_Exchange(is_orig: bool) = record {
-	packet_length : uint32;
+type SSH1_Key_Exchange(is_orig: bool, packet_length: uint32) = record {
 	pad_fill      : bytestring &length = 8 - (packet_length % 8);
 	msg_type      : uint8;
 	message       : SSH1_Message(is_orig, msg_type, packet_length - 5);
 	crc           : uint32;
-} &length = packet_length + 4 + 8 - (packet_length % 8);
+} &length = packet_length + 8 - (packet_length % 8);
 
 type SSH1_Message(is_orig: bool, msg_type: uint8, length: uint32) = case msg_type of {
 	SSH_SMSG_PUBLIC_KEY  -> public_key  : SSH1_PUBLIC_KEY(length);
@@ -73,8 +75,7 @@ type ssh1_mp_int = record {
 
 ## SSH2
 
-type SSH2_Header(is_orig: bool) = record {
-	packet_length  : uint32;
+type SSH2_Header(is_orig: bool, packet_length: uint32) = record {
 	padding_length : uint8;
 	msg_type       : uint8;
 } &let {
@@ -82,11 +83,11 @@ type SSH2_Header(is_orig: bool) = record {
 	detach         : bool = $context.connection.update_state(ENCRYPTED, is_orig) &if(msg_type == MSG_NEWKEYS);
 };
 
-type SSH2_Key_Exchange(is_orig: bool) = record {
-	header   : SSH2_Header(is_orig);
+type SSH2_Key_Exchange(is_orig: bool, packet_length: uint32) = record {
+	header   : SSH2_Header(is_orig, packet_length);
 	payload  : SSH2_Message(is_orig, header.msg_type, header.payload_length);
 	pad      : bytestring &length=header.padding_length;
-} &length=header.packet_length + 4;
+} &length=packet_length;
 
 type SSH2_Message(is_orig: bool, msg_type: uint8, length: uint32) = case $context.connection.get_state(is_orig) of {
 	KEX_INIT   -> kex        : SSH2_KEXINIT(length, is_orig);


### PR DESCRIPTION
SSH protocol now assesses the packet length at an earlier stage within binpac. Stops SSH analyzer constantly raising binpac exceptions. Seems to be because a packet continues to go through binpac when empty and only calls the next packet when asked for more data and not on operations.

This was an issue when client version exchange packets got to the end of version exchange. At this point, the packet has no more information but continues until more information is requested of it. Hence this packet continues on to the SSH_Key_Exchange function. Before any information is requested of the packet, Bro attempts to find the SSH version so it can send the packet into SSH1 or SSH2.

The SSH version is only set when a server version exchange packet is seen, hence, as we are still assessing the client version exchange packet, the SSH version has not yet been set and hence returns an invalid result. This causes a binpac exception which occurs in every single SSH connection.

The fix below expands the SSH_Key_Exchange function to first get the packet_length field (which is common to both SSH1 and SSH2) before doing the version decision step. Hence the 'empty' client version exchange packet will not reach the point where the SSH version is queried and the protocol can continue to be analysed without throwing a binpac exception.

Due to this change, the packet length is required to be passed down from the SSH_Key_Exchange.