### PR TITLE
Better reporter for Brostring with embedded NUL

### DIFF
--- a/src/BroString.cc
+++ b/src/BroString.cc
@@ -166,14 +166,16 @@ void BroString::Set(const BroString& str)
 
 const char* BroString::CheckString() const
 	{
+	void * nulTerm;
 	if ( n == 0 )
 		return "";
 
-	if ( memchr(b, '\0', n + final_NUL) != &b[n] )
+	nulTerm = memchr(b, '\0', n + final_NUL);
+	if ( nulTerm != &b[n] )
 		{
 		// Either an embedded NUL, or no final NUL.
 		char* exp_s = Render();
-		if ( b[n-1] != '\0' )
+		if ( nulTerm == NULL )
 			reporter->Error("string without NUL terminator: \"%s\"", exp_s);
 		else
 			reporter->Error("string with embedded NUL: \"%s\"", exp_s);


### PR DESCRIPTION
A BroString with embedded null can be produced with some command like
`curl 127.0.0.1/%00more`

`memchr`returns NULL if it did not find a NUL character.
So we should use this to differentiate between string missing NUL terminator and string with embedded NUL before terminator