### PR TITLE
Timeout TCP RPC analyzer using rpc_timeout value.

### DIFF
--- a/src/analyzer/protocol/rpc/RPC.cc
+++ b/src/analyzer/protocol/rpc/RPC.cc
@@ -705,9 +705,8 @@ RPC_Analyzer::RPC_Analyzer(const char* name, Connection* conn,
 	: tcp::TCP_ApplicationAnalyzer(name, conn),
 	  interp(arg_interp), orig_rpc(), resp_rpc()
 	{
-	if ( Conn()->ConnTransport() == TRANSPORT_UDP )
-		ADD_ANALYZER_TIMER(&RPC_Analyzer::ExpireTimer,
-			network_time + rpc_timeout, 1, TIMER_RPC_EXPIRE);
+	ADD_ANALYZER_TIMER(&RPC_Analyzer::ExpireTimer,
+		network_time + rpc_timeout, 1, TIMER_RPC_EXPIRE);
 	}
 
 RPC_Analyzer::~RPC_Analyzer()


### PR DESCRIPTION
Wondering if you are open to having rpc_timeout apply to TCP connections? In our Bro instance we found we occasionally dropped TCP frames and without a timeout these analyzers would hang around indefinitely. The default rpc_timeout value is 24 seconds which seems like more than enough time to wait even for TCP connections. 