### PR TITLE
Fix dump_packet & dump_current_packet ignoring file_name

### DIFF
--- a/src/bro.bif
+++ b/src/bro.bif
@@ -29,7 +29,6 @@ using namespace std;
 TableType* var_sizes;
 
 static iosource::PktDumper* addl_pkt_dumper = 0;
-static StringVal* open_file_dumper;
 
 bro_int_t parse_int(const char*& fmt)
 	{
@@ -3292,16 +3291,15 @@ function dump_current_packet%(file_name: string%) : bool
 		{
 		addl_pkt_dumper = iosource_mgr->OpenPktDumper(file_name->CheckString(), true);
 		{
-	else if ( addl_pkt_dumper && open_file_dumper != file_name)
+	else if ( addl_pkt_dumper && addl_pkt_dumper->Path() != file_name->CheckString())
 		{
 		addl_pkt_dumper->Close();
 		addl_pkt_dumper = iosource_mgr->OpenPktDumper(file_name->CheckString(), true);
 		}
-	// else if (addl_pkt_dumper && open_file_dumper == file_name) do nothing
+	// else if (addl_pkt_dumper && addl_pkt_dumper->Path() == file_name->CheckString()) do nothing
 
 	if ( addl_pkt_dumper )
 		{
-		open_file_dumper = file_name;
 		addl_pkt_dumper->Dump(pkt);
 		}
 
@@ -3376,17 +3374,15 @@ function dump_packet%(pkt: pcap_packet, file_name: string%) : bool
 		{
 		addl_pkt_dumper = iosource_mgr->OpenPktDumper(file_name->CheckString(), true);
 		{
-	else if ( addl_pkt_dumper && open_file_dumper != file_name)
+	else if ( addl_pkt_dumper && addl_pkt_dumper->Path() != file_name->CheckString())
 		{
 		addl_pkt_dumper->Close();
 		addl_pkt_dumper = iosource_mgr->OpenPktDumper(file_name->CheckString(), true);
 		}
-	// else if (addl_pkt_dumper && open_file_dumper == file_name) do nothing
+	// else if (addl_pkt_dumper && addl_pkt_dumper->Path() == file_name->CheckString()) do nothing
 
 	if ( addl_pkt_dumper )
 		{
-		open_file_dumper = file_name;
-		
 		pkt_timeval ts;
 		uint32 caplen, len, link_type;
 		u_char *data;

--- a/src/bro.bif
+++ b/src/bro.bif
@@ -29,6 +29,7 @@ using namespace std;
 TableType* var_sizes;
 
 static iosource::PktDumper* addl_pkt_dumper = 0;
+static StringVal* open_file_dumper;
 
 bro_int_t parse_int(const char*& fmt)
 	{
@@ -3288,10 +3289,19 @@ function dump_current_packet%(file_name: string%) : bool
 		return new Val(0, TYPE_BOOL);
 
 	if ( ! addl_pkt_dumper )
+		{
 		addl_pkt_dumper = iosource_mgr->OpenPktDumper(file_name->CheckString(), true);
+		{
+	else if ( addl_pkt_dumper && open_file_dumper != file_name)
+		{
+		addl_pkt_dumper->Close();
+		addl_pkt_dumper = iosource_mgr->OpenPktDumper(file_name->CheckString(), true);
+		}
+	// else if (addl_pkt_dumper && open_file_dumper == file_name) do nothing
 
 	if ( addl_pkt_dumper )
 		{
+		open_file_dumper = file_name;
 		addl_pkt_dumper->Dump(pkt);
 		}
 
@@ -3363,10 +3373,20 @@ function get_current_packet_header%(%) : raw_pkt_hdr
 function dump_packet%(pkt: pcap_packet, file_name: string%) : bool
 	%{
 	if ( ! addl_pkt_dumper )
+		{
 		addl_pkt_dumper = iosource_mgr->OpenPktDumper(file_name->CheckString(), true);
+		{
+	else if ( addl_pkt_dumper && open_file_dumper != file_name)
+		{
+		addl_pkt_dumper->Close();
+		addl_pkt_dumper = iosource_mgr->OpenPktDumper(file_name->CheckString(), true);
+		}
+	// else if (addl_pkt_dumper && open_file_dumper == file_name) do nothing
 
 	if ( addl_pkt_dumper )
 		{
+		open_file_dumper = file_name;
+		
 		pkt_timeval ts;
 		uint32 caplen, len, link_type;
 		u_char *data;


### PR DESCRIPTION
This fixes an issue where `dump_packet` and `dump_current_packet` ignoring the `file_name` parameter if `addl_pkt_dumper` is already pointing to some file (doesn't matter which file...).  

The fix checks if `file_name` is different from the opened one and if needed closes `addl_pkt_dumper` and opens the correct `file_name`.

http://mailman.icsi.berkeley.edu/pipermail/bro/2018-May/013184.html