### PR TITLE
Fix for BIT-1927: notice/extend-email relocation

### DIFF
--- a/scripts/base/frameworks/notice/__load__.bro
+++ b/scripts/base/frameworks/notice/__load__.bro
@@ -8,10 +8,6 @@
 @load ./actions/page
 @load ./actions/add-geodata
 
-# There shouldn't be any default overhead from loading these since they 
-# *should* only do anything when notices have the ACTION_EMAIL action applied.
-@load ./extend-email/hostnames
-
 # The cluster framework must be loaded first.
 @load base/frameworks/cluster
 

--- a/scripts/policy/frameworks/notice/__load__.bro
+++ b/scripts/policy/frameworks/notice/__load__.bro
@@ -1,0 +1,3 @@
+# There shouldn't be any default overhead from loading these since they
+# *should* only do anything when notices have the ACTION_EMAIL action applied.
+@load ./extend-email/hostnames

--- a/scripts/policy/frameworks/notice/extend-email/hostnames.bro
+++ b/scripts/policy/frameworks/notice/extend-email/hostnames.bro
@@ -3,7 +3,7 @@
 ##! :bro:type:`Notice::Info`'s *src* and *dst* fields as determined by a
 ##! DNS lookup.
 
-@load ../main
+@load base/frameworks/notice/main
 
 module Notice;
 

--- a/scripts/site/local.bro
+++ b/scripts/site/local.bro
@@ -85,6 +85,9 @@
 # Detect SHA1 sums in Team Cymru's Malware Hash Registry.
 @load frameworks/files/detect-MHR
 
+# Extend email alerting to include hostnames
+@load policy/frameworks/notice/extend-email/hostnames
+
 # Uncomment the following line to enable detection of the heartbleed attack. Enabling
 # this might impact performance a bit.
 # @load policy/protocols/ssl/heartbleed


### PR DESCRIPTION
This is a fairly straightforward change. Previously, users had no
control over whether this script was loaded. By relocating it to
policy, users can now choose whether or not this is necessary
functionality without modifying core Bro scripts.