### PR TITLE
Added support for making optional the extraction of DNS entries from X509 SAN as Intel::seen records.

### DIFF
--- a/scripts/policy/frameworks/intel/seen/x509.bro
+++ b/scripts/policy/frameworks/intel/seen/x509.bro
@@ -2,9 +2,16 @@
 @load base/files/x509
 @load ./where-locations
 
+module Intel;
+
+export {
+        ## Enables the extraction of subject alternate names from the X509 SAN DNS field
+        const enable_x509_ext_subject_alternative_name = T &redef;
+}
+
 event x509_ext_subject_alternative_name(f: fa_file, ext: X509::SubjectAlternativeName)
 	{
-	if ( ext?$dns )
+	if ( enable_x509_ext_subject_alternative_name && ext?$dns )
 		{
 		for ( i in ext$dns )
 			Intel::seen([$indicator=ext$dns[i],


### PR DESCRIPTION
This patch adds support for making optional the extraction of DNS entries from X509 SAN as Intel::seen records. A new Intel::enable_x509_ext_subject_alternative_name config parameter is being introduced, defaulting to T, which means that out of the box it will not change the current behaviour. We are proposing this change as we are having quite a few false positive Intel matches for certificates that are generated for a very large number of Subject Alternative Names (usual practice for some CDN / cloud providers such as Cloudflare).