### PR TITLE
Added missing tcp-state for signature dpd_rfb_server

### DIFF
--- a/scripts/base/protocols/rfb/dpd.sig
+++ b/scripts/base/protocols/rfb/dpd.sig
@@ -1,6 +1,7 @@
 signature dpd_rfb_server {
 	ip-proto == tcp
 	payload /^RFB/
+	tcp-state responder
 	requires-reverse-signature dpd_rfb_client
 	enable "rfb"
 }


### PR DESCRIPTION
Signature dpd_rfb_server is missing its tcp-state, which should be "responder".