### PR TITLE
Add DCE_RPC exchange_mapi operations to relevant consts.bro file

### DIFF
--- a/scripts/base/protocols/dce-rpc/consts.bro
+++ b/scripts/base/protocols/dce-rpc/consts.bro
@@ -1431,6 +1431,11 @@ export {
 		["a4f1db00-ca47-1067-b31f-00dd010662da",0x07] = "EcRGetDCName",
 		["a4f1db00-ca47-1067-b31f-00dd010662da",0x08] = "EcRNetGetDCName",
 		["a4f1db00-ca47-1067-b31f-00dd010662da",0x09] = "EcDoRpcExt",
+		["a4f1db00-ca47-1067-b31f-00dd010662da",0x0a] = "EcDoConnectEx",
+		["a4f1db00-ca47-1067-b31f-00dd010662da",0x0b] = "EcDoRpcExt2",
+		["a4f1db00-ca47-1067-b31f-00dd010662da",0x0c] = "EcUnknown0xC",
+		["a4f1db00-ca47-1067-b31f-00dd010662da",0x0d] = "EcUnknown0xD",
+		["a4f1db00-ca47-1067-b31f-00dd010662da",0x0e] = "EcDoAsyncConnectEx",
 
 		# drsuapi
 		["e3514235-4b06-11d1-ab04-00c04fc2dcd2",0x00] = "DRSBind",


### PR DESCRIPTION
New operations names and opnums come from the MSDN documentation
and OpenChange Project.

Relevant links:
- https://msdn.microsoft.com/en-us/library/ee178982(v=exchg.80).aspx
- https://github.com/inverse-inc/openchange/blob/master/mapiproxy/servers/default/emsmdb/dcesrv_exchange_emsmdb.c