### PR TITLE
Fix for SSH capabilities$is_server bug

### DIFF
--- a/src/analyzer/protocol/ssh/ssh-analyzer.pac
+++ b/src/analyzer/protocol/ssh/ssh-analyzer.pac
@@ -101,7 +101,7 @@ refine flow SSH_Flow += {
 			}
 
 
-		result->Assign(6, new Val(${msg.is_orig}, TYPE_BOOL));
+		result->Assign(6, new Val(!${msg.is_orig}, TYPE_BOOL));
 
 		BifEvent::generate_ssh_capabilities(connection()->bro_analyzer(),
 			connection()->bro_analyzer()->Conn(), bytestring_to_val(${msg.cookie}),

--- a/testing/btest/Baseline/core.tunnels.gre/ssh.log
+++ b/testing/btest/Baseline/core.tunnels.gre/ssh.log
@@ -3,8 +3,8 @@
 #empty_field	(empty)
 #unset_field	-
 #path	ssh
-#open	2017-08-01-16-46-22
+#open	2018-10-16-14-52-51
 #fields	ts	uid	id.orig_h	id.orig_p	id.resp_h	id.resp_p	version	auth_success	auth_attempts	direction	client	server	cipher_alg	mac_alg	compression_alg	kex_alg	host_key_alg	host_key
 #types	time	string	addr	port	addr	port	count	bool	count	enum	string	string	string	string	string	string	string	string
-1055289978.855137	CtPZjS20MLrsMUOJi2	66.59.111.190	40264	172.28.2.3	22	2	-	0	-	SSH-2.0-OpenSSH_3.6.1p1	SSH-1.99-OpenSSH_3.1p1	aes128-cbc	hmac-md5	none	diffie-hellman-group-exchange-sha1	ssh-rsa	20:7c:e5:96:b0:4e:ce:a4:db:e4:aa:29:e8:90:98:07
-#close	2017-08-01-16-46-22
+1055289978.855137	CtPZjS20MLrsMUOJi2	66.59.111.190	40264	172.28.2.3	22	2	-	0	-	SSH-2.0-OpenSSH_3.6.1p1	SSH-1.99-OpenSSH_3.1p1	blowfish-cbc	hmac-md5	zlib	diffie-hellman-group-exchange-sha1	ssh-rsa	20:7c:e5:96:b0:4e:ce:a4:db:e4:aa:29:e8:90:98:07
+#close	2018-10-16-14-52-51

--- a/testing/btest/Baseline/scripts.base.protocols.ssh.basic/.stdout
+++ b/testing/btest/Baseline/scripts.base.protocols.ssh.basic/.stdout
@@ -1,4 +1,3 @@
-auth_result, CHhAvVGS1DHFjwGM9, F, 2
 auth_result, ClEkJM2Vm5giqnMf4h, T, 1
 auth_result, C4J4Th3PJpwUYZZ6gc, T, 3
 auth_result, Ck51lg1bScffFj34Ri, T, 2

--- a/testing/btest/Baseline/scripts.base.protocols.ssh.basic/ssh.log
+++ b/testing/btest/Baseline/scripts.base.protocols.ssh.basic/ssh.log
@@ -3,14 +3,14 @@
 #empty_field	(empty)
 #unset_field	-
 #path	ssh
-#open	2017-08-01-16-26-21
+#open	2018-10-16-15-00-07
 #fields	ts	uid	id.orig_h	id.orig_p	id.resp_h	id.resp_p	version	auth_success	auth_attempts	direction	client	server	cipher_alg	mac_alg	compression_alg	kex_alg	host_key_alg	host_key
 #types	time	string	addr	port	addr	port	count	bool	count	enum	string	string	string	string	string	string	string	string
-1324071333.792887	CHhAvVGS1DHFjwGM9	192.168.1.79	51880	131.159.21.1	22	2	F	2	-	SSH-2.0-OpenSSH_5.9	SSH-2.0-OpenSSH_5.8	aes128-ctr	hmac-md5	none	ecdh-sha2-nistp256	ssh-rsa	a7:26:62:3f:75:1f:33:8a:f3:32:90:8b:73:fd:2c:83
+1324071333.792887	CHhAvVGS1DHFjwGM9	192.168.1.79	51880	131.159.21.1	22	2	-	0	-	SSH-2.0-OpenSSH_5.9	SSH-2.0-OpenSSH_5.8	aes128-ctr	hmac-md5	zlib@openssh.com	ecdh-sha2-nistp256	ecdsa-sha2-nistp256	a7:26:62:3f:75:1f:33:8a:f3:32:90:8b:73:fd:2c:83
 1409516196.413240	ClEkJM2Vm5giqnMf4h	10.0.0.18	40184	128.2.6.88	41644	2	T	1	-	SSH-2.0-OpenSSH_6.6	SSH-2.0-OpenSSH_5.9p1 Debian-5ubuntu1.1	aes128-ctr	hmac-md5	none	ecdh-sha2-nistp256	ssh-rsa	8a:8d:55:28:1e:71:04:99:94:43:22:89:e5:ff:e9:03
 1419870189.489202	C4J4Th3PJpwUYZZ6gc	192.168.2.1	57189	192.168.2.158	22	2	T	3	-	SSH-2.0-OpenSSH_6.2	SSH-1.99-OpenSSH_6.6.1p1 Ubuntu-2ubuntu2	aes128-ctr	hmac-md5-etm@openssh.com	none	diffie-hellman-group-exchange-sha256	ssh-rsa	28:78:65:c1:c3:26:f7:1b:65:6a:44:14:d0:04:8f:b3
 1419870206.111841	CtPZjS20MLrsMUOJi2	192.168.2.1	57191	192.168.2.158	22	1	-	0	-	SSH-1.5-OpenSSH_6.2	SSH-1.99-OpenSSH_6.6.1p1 Ubuntu-2ubuntu2	-	-	-	-	-	a1:73:d1:e1:25:72:79:71:56:56:65:ed:81:bf:67:98
-1419996264.344957	CUM0KZ3MLUfNB0cl11	192.168.2.1	55179	192.168.2.158	2200	2	-	0	-	SSH-2.0-OpenSSH_6.2	SSH-2.0-paramiko_1.15.2	aes128-ctr	hmac-sha1	none	diffie-hellman-group14-sha1	ssh-rsa	60:73:38:44:cb:51:86:65:7f:de:da:a2:2b:5a:57:d5
+1419996264.344957	CUM0KZ3MLUfNB0cl11	192.168.2.1	55179	192.168.2.158	2200	2	-	0	-	SSH-2.0-OpenSSH_6.2	SSH-2.0-paramiko_1.15.2	aes128-ctr	hmac-md5	none	diffie-hellman-group-exchange-sha1	ssh-rsa	60:73:38:44:cb:51:86:65:7f:de:da:a2:2b:5a:57:d5
 1420588548.729561	CmES5u32sYpV7JYN	192.168.2.1	56594	192.168.2.158	22	1	-	0	-	SSH-1.5-OpenSSH_5.3	SSH-1.99-OpenSSH_6.6.1p1 Ubuntu-2ubuntu2	-	-	-	-	-	a1:73:d1:e1:25:72:79:71:56:56:65:ed:81:bf:67:98
 1420590124.885826	CP5puj4I8PtEU4qzYg	192.168.2.1	56821	192.168.2.158	22	1	-	0	-	SSH-1.5-OpenSSH_6.2	SSH-1.99-OpenSSH_6.6.1p1 Ubuntu-2ubuntu2	-	-	-	-	-	a1:73:d1:e1:25:72:79:71:56:56:65:ed:81:bf:67:98
 1420590308.781231	C37jN32gN3y3AZzyf6	192.168.2.1	56837	192.168.2.158	22	1	-	0	-	SSH-1.5-OpenSSH_6.2	SSH-1.99-OpenSSH_6.6.1p1 Ubuntu-2ubuntu2	-	-	-	-	-	a1:73:d1:e1:25:72:79:71:56:56:65:ed:81:bf:67:98
@@ -23,9 +23,9 @@
 1420860283.057451	C9mvWx3ezztgzcexV7	192.168.1.32	41164	128.2.10.238	22	2	T	5	-	SSH-2.0-OpenSSH_6.6p1-hpn14v4	SSH-1.99-OpenSSH_3.4+p1+gssapi+OpenSSH_3.7.1buf_fix+2006100301	aes128-cbc	hmac-md5	none	diffie-hellman-group-exchange-sha1	ssh-rsa	7f:e5:81:92:26:77:05:44:c4:60:fb:cd:89:c8:81:ee
 1420860616.428738	CNnMIj2QSd84NKf7U3	192.168.1.32	33910	128.2.13.133	22	2	T	1	-	SSH-2.0-OpenSSH_6.6p1-hpn14v4	SSH-2.0-OpenSSH_5.3	aes128-ctr	hmac-md5	none	diffie-hellman-group-exchange-sha256	ssh-rsa	93:d8:4c:0d:b2:c3:2e:da:b9:c0:67:db:e4:8f:95:04
 1420868281.665872	C7fIlMZDuRiqjpYbb	192.168.1.32	41268	128.2.10.238	22	2	F	6	-	SSH-2.0-OpenSSH_6.6	SSH-1.99-OpenSSH_3.4+p1+gssapi+OpenSSH_3.7.1buf_fix+2006100301	aes128-cbc	hmac-md5	none	diffie-hellman-group-exchange-sha1	ssh-rsa	7f:e5:81:92:26:77:05:44:c4:60:fb:cd:89:c8:81:ee
-1420917487.227035	CpmdRlaUoJLN3uIRa	192.168.1.31	52294	192.168.1.32	22	2	T	2	-	SSH-2.0-OpenSSH_6.7	SSH-2.0-OpenSSH_6.7	chacha20-poly1305@openssh.com	hmac-sha2-512-etm@openssh.com	none	curve25519-sha256@libssh.org	ssh-ed25519	e4:b1:8e:ca:6e:0e:e5:3c:7e:a4:0e:70:34:9d:b2:b1
-1421006072.224828	C1Xkzz2MaGtLrc1Tla	192.168.1.31	51489	192.168.1.32	22	2	T	3	-	SSH-2.0-OpenSSH_6.7	SSH-2.0-OpenSSH_6.7	chacha20-poly1305@openssh.com	hmac-sha2-512-etm@openssh.com	none	curve25519-sha256@libssh.org	ssh-ed25519	e4:b1:8e:ca:6e:0e:e5:3c:7e:a4:0e:70:34:9d:b2:b1
-1421041177.031508	CLNN1k2QMum1aexUK7	192.168.1.32	58641	131.103.20.168	22	2	F	1	-	SSH-2.0-OpenSSH_6.7	SSH-2.0-OpenSSH_5.3	aes128-ctr	hmac-md5	none	diffie-hellman-group-exchange-sha256	ssh-rsa	97:8c:1b:f2:6f:14:6b:5c:3b:ec:aa:46:46:74:7c:40
-1421041299.777962	CBA8792iHmnhPLksKa	192.168.1.32	58646	131.103.20.168	22	2	T	1	-	SSH-2.0-OpenSSH_6.7	SSH-2.0-OpenSSH_5.3	aes128-ctr	hmac-md5	none	diffie-hellman-group-exchange-sha256	ssh-rsa	97:8c:1b:f2:6f:14:6b:5c:3b:ec:aa:46:46:74:7c:40
-1421041526.353524	CGLPPc35OzDQij1XX8	192.168.1.32	58649	131.103.20.168	22	2	T	1	-	SSH-2.0-OpenSSH_6.7	SSH-2.0-OpenSSH_5.3	aes128-ctr	hmac-md5	none	diffie-hellman-group-exchange-sha256	ssh-rsa	97:8c:1b:f2:6f:14:6b:5c:3b:ec:aa:46:46:74:7c:40
-#close	2017-08-01-16-26-21
+1420917487.227035	CpmdRlaUoJLN3uIRa	192.168.1.31	52294	192.168.1.32	22	2	T	2	-	SSH-2.0-OpenSSH_6.7	SSH-2.0-OpenSSH_6.7	chacha20-poly1305@openssh.com	hmac-sha2-512-etm@openssh.com	none	curve25519-sha256@libssh.org	ssh-ed25519-cert-v01@openssh.com	e4:b1:8e:ca:6e:0e:e5:3c:7e:a4:0e:70:34:9d:b2:b1
+1421006072.224828	C1Xkzz2MaGtLrc1Tla	192.168.1.31	51489	192.168.1.32	22	2	T	3	-	SSH-2.0-OpenSSH_6.7	SSH-2.0-OpenSSH_6.7	chacha20-poly1305@openssh.com	hmac-sha2-512-etm@openssh.com	none	curve25519-sha256@libssh.org	ssh-ed25519-cert-v01@openssh.com	e4:b1:8e:ca:6e:0e:e5:3c:7e:a4:0e:70:34:9d:b2:b1
+1421041177.031508	CLNN1k2QMum1aexUK7	192.168.1.32	58641	131.103.20.168	22	2	F	1	-	SSH-2.0-OpenSSH_6.7	SSH-2.0-OpenSSH_5.3	aes128-ctr	umac-64@openssh.com	none	diffie-hellman-group-exchange-sha256	ssh-rsa	97:8c:1b:f2:6f:14:6b:5c:3b:ec:aa:46:46:74:7c:40
+1421041299.777962	CBA8792iHmnhPLksKa	192.168.1.32	58646	131.103.20.168	22	2	T	1	-	SSH-2.0-OpenSSH_6.7	SSH-2.0-OpenSSH_5.3	aes128-ctr	umac-64@openssh.com	none	diffie-hellman-group-exchange-sha256	ssh-rsa	97:8c:1b:f2:6f:14:6b:5c:3b:ec:aa:46:46:74:7c:40
+1421041526.353524	CGLPPc35OzDQij1XX8	192.168.1.32	58649	131.103.20.168	22	2	T	1	-	SSH-2.0-OpenSSH_6.7	SSH-2.0-OpenSSH_5.3	aes128-ctr	umac-64@openssh.com	none	diffie-hellman-group-exchange-sha256	ssh-rsa	97:8c:1b:f2:6f:14:6b:5c:3b:ec:aa:46:46:74:7c:40
+#close	2018-10-16-15-00-07

--- a/testing/btest/Baseline/scripts.base.protocols.ssh.curve25519_kex/ssh.log
+++ b/testing/btest/Baseline/scripts.base.protocols.ssh.curve25519_kex/ssh.log
@@ -3,8 +3,8 @@
 #empty_field	(empty)
 #unset_field	-
 #path	ssh
-#open	2017-10-05-19-34-53
+#open	2018-10-16-15-27-29
 #fields	ts	uid	id.orig_h	id.orig_p	id.resp_h	id.resp_p	version	auth_success	auth_attempts	direction	client	server	cipher_alg	mac_alg	compression_alg	kex_alg	host_key_alg	host_key
 #types	time	string	addr	port	addr	port	count	bool	count	enum	string	string	string	string	string	string	string	string
-1505524964.630115	CHhAvVGS1DHFjwGM9	192.168.1.100	60906	192.168.1.32	22	2	T	2	-	SSH-2.0-OpenSSH_7.4	SSH-2.0-OpenSSH_7.5	chacha20-poly1305@openssh.com	hmac-sha2-512-etm@openssh.com	none	curve25519-sha256	ssh-ed25519	e4:b1:8e:ca:6e:0e:e5:3c:7e:a4:0e:70:34:9d:b2:b1
-#close	2017-10-05-19-34-53
+1505524964.630115	CHhAvVGS1DHFjwGM9	192.168.1.100	60906	192.168.1.32	22	2	T	2	-	SSH-2.0-OpenSSH_7.4	SSH-2.0-OpenSSH_7.5	chacha20-poly1305@openssh.com	hmac-sha2-512-etm@openssh.com	none	curve25519-sha256	ssh-ed25519-cert-v01@openssh.com	e4:b1:8e:ca:6e:0e:e5:3c:7e:a4:0e:70:34:9d:b2:b1
+#close	2018-10-16-15-27-29


### PR DESCRIPTION
Fix SSH analyzer bug where is_server in capabilities is wrong.

The ssh_capabilities event includes the capabilities reported by either the server or the client. The record also includes a field, is_server, so that scripts can determine which endpoint is reporting its capabilities. That field was being set incorrectly (it was being set as is_client rather than is_server, so it needed to be negated).

This simple bug had some larger repercussions. RFC 4253 provides a method for client and server to agree on algorithms used in the SSH connection. Bro was calculating these incorrectly. Some of these, such as the encryption algorithm, are also used to determine whether or not Bro should attempt to detect successful versus failed authentications. In some cases, Bro would get this wrong, and make a guess when it could not correctly determine the authentication outcome.