### PR TITLE
Tell OpenSSL that MD5 is not used for security

### DIFF
--- a/src/DFA.cc
+++ b/src/DFA.cc
@@ -6,6 +6,7 @@
 
 #include "EquivClass.h"
 #include "DFA.h"
+#include "digest.h"
 
 unsigned int DFA_State::transition_counter = 0;
 
@@ -337,7 +338,7 @@ DFA_State* DFA_State_Cache::Lookup(const NFA_state_list& nfas,
 	// We use the short MD5 instead of the full string for the
 	// HashKey because the data is copied into the key.
 	u_char digest[16];
-	MD5(id_tag, p - id_tag, digest);
+	internal_md5(id_tag, p - id_tag, digest);
 
 	*hash = new HashKey(&digest, sizeof(digest));
 	CacheEntry* e = states.Lookup(*hash);
@@ -395,7 +396,7 @@ DFA_Machine::DFA_Machine(NFA_Machine* n, EquivClass* arg_ec)
 	{
 	state_count = 0;
 
-	nfa = n; 
+	nfa = n;
 	Ref(n);
 
 	ec = arg_ec;

--- a/src/DNS_Mgr.cc
+++ b/src/DNS_Mgr.cc
@@ -2,7 +2,6 @@
 
 #include "bro-config.h"
 
-#include <openssl/md5.h>
 #include <sys/types.h>
 #include <sys/socket.h>
 #ifdef TIME_WITH_SYS_TIME
@@ -36,6 +35,7 @@
 #include "Var.h"
 #include "Reporter.h"
 #include "iosource/Manager.h"
+#include "digest.h"
 
 extern "C" {
 extern int select(int, fd_set *, fd_set *, fd_set *, struct timeval *);
@@ -445,7 +445,7 @@ void DNS_Mgr::InitPostScript()
 static TableVal* fake_name_lookup_result(const char* name)
 	{
 	uint32 hash[4];
-	MD5(reinterpret_cast<const u_char*>(name), strlen(name),
+	internal_md5(reinterpret_cast<const u_char*>(name), strlen(name),
 	    reinterpret_cast<u_char*>(hash));
 	ListVal* hv = new ListVal(TYPE_ADDR);
 	hv->Append(new AddrVal(hash));

--- a/src/OpaqueVal.h
+++ b/src/OpaqueVal.h
@@ -56,7 +56,7 @@ protected:
 	DECLARE_SERIAL(MD5Val);
 
 private:
-	MD5_CTX ctx;
+	EVP_MD_CTX ctx;
 };
 
 class SHA1Val : public HashVal {

--- a/src/analyzer/protocol/mime/MIME.h
+++ b/src/analyzer/protocol/mime/MIME.h
@@ -2,7 +2,7 @@
 #define ANALYZER_PROTOCOL_MIME_MIME_H
 
 #include <assert.h>
-#include <openssl/md5.h>
+#include <openssl/evp.h>
 #include <stdio.h>
 #include <vector>
 #include <queue>
@@ -252,7 +252,7 @@ protected:
 	int data_start;
 	int compute_content_hash;
 	int content_hash_length;
-	MD5_CTX md5_hash;
+	EVP_MD_CTX md5_hash;
 	vector<const BroString*> entity_content;
 	vector<const BroString*> all_content;
 

--- a/src/digest.h
+++ b/src/digest.h
@@ -9,6 +9,7 @@
 
 #include <openssl/md5.h>
 #include <openssl/sha.h>
+#include <openssl/evp.h>
 
 #include "Reporter.h"
 
@@ -35,22 +36,56 @@ inline const char* sha256_digest_print(const u_char digest[SHA256_DIGEST_LENGTH]
 	return digest_print(digest, SHA256_DIGEST_LENGTH);
 	}
 
-inline void md5_init(MD5_CTX* c)
+inline void md5_init(EVP_MD_CTX* c)
 	{
-	if ( ! MD5_Init(c) )
+	EVP_MD_CTX_init(c);
+	/* Allow this to work even if FIPS disables it */
+#ifdef EVP_MD_CTX_FLAG_NON_FIPS_ALLOW
+	EVP_MD_CTX_set_flags(c, EVP_MD_CTX_FLAG_NON_FIPS_ALLOW);
+#endif
+	if ( ! EVP_DigestInit_ex(c, EVP_md5(), NULL) )
 		reporter->InternalError("MD5_Init failed");
 	}
 
-inline void md5_update(MD5_CTX* c, const void* data, unsigned long len)
+inline void md5_update(EVP_MD_CTX* c, const void* data, unsigned long len)
 	{
-	if ( ! MD5_Update(c, data, len) )
+	if ( ! EVP_DigestUpdate(c, data, len) )
 		reporter->InternalError("MD5_Update failed");
 	}
 
-inline void md5_final(MD5_CTX* c, u_char md[MD5_DIGEST_LENGTH])
+inline void md5_final(EVP_MD_CTX* c, u_char md[MD5_DIGEST_LENGTH])
 	{
-	if ( ! MD5_Final(md, c) )
+	if ( ! EVP_DigestFinal(c, md, NULL) )
 		reporter->InternalError("MD5_Final failed");
+	}
+
+inline unsigned char* internal_md5(const unsigned char *d, size_t n, unsigned char *md)
+	{
+		EVP_MD_CTX c;
+		static unsigned char m[MD5_DIGEST_LENGTH];
+
+		if (md == NULL)
+			md = m;
+		md5_init(&c);
+	#ifndef CHARSET_EBCDIC
+		md5_update(&c, d, n);
+	#else
+		{
+			char temp[1024];
+			unsigned long chunk;
+
+			while (n > 0) {
+				chunk = (n > sizeof(temp)) ? sizeof(temp) : n;
+				ebcdic2ascii(temp, d, chunk);
+				md5_update(&c, temp, chunk);
+				n -= chunk;
+				d += chunk;
+			}
+		}
+	#endif
+		md5_final(&c, md);
+		OPENSSL_cleanse(&c, sizeof(c)); /* security consideration */
+		return md;
 	}
 
 inline void sha1_init(SHA_CTX* c)

--- a/src/file_analysis/Manager.cc
+++ b/src/file_analysis/Manager.cc
@@ -10,6 +10,7 @@
 #include "Var.h"
 #include "Event.h"
 #include "UID.h"
+#include "digest.h"
 
 #include "plugin/Manager.h"
 #include "analyzer/Manager.h"
@@ -93,7 +94,7 @@ string Manager::HashHandle(const string& handle) const
 	uint64 hash[2];
 	string msg(handle + salt);
 
-	MD5(reinterpret_cast<const u_char*>(msg.data()), msg.size(),
+	internal_md5(reinterpret_cast<const u_char*>(msg.data()), msg.size(),
 	    reinterpret_cast<u_char*>(hash));
 
 	return Bro::UID(bits_per_uid, hash, 2).Base62("F");

--- a/src/probabilistic/Hasher.cc
+++ b/src/probabilistic/Hasher.cc
@@ -1,7 +1,7 @@
 // See the file "COPYING" in the main distribution directory for copyright.
 
 #include <typeinfo>
-#include <openssl/md5.h>
+#include <openssl/evp.h>
 
 #include "Hasher.h"
 #include "NetVar.h"
@@ -123,13 +123,13 @@ Hasher::digest UHF::hash(const void* x, size_t n) const
 		Hasher::digest rval;
 	} u;
 
-	MD5(reinterpret_cast<const unsigned char*>(x), n, u.d);
+	internal_md5(reinterpret_cast<const unsigned char*>(x), n, u.d);
 
 	const unsigned char* s = reinterpret_cast<const unsigned char*>(&seed);
 	for ( size_t i = 0; i < 16; ++i )
-		u.d[i] ^= s[i % sizeof(seed)];
+		d[i] ^= s[i % sizeof(seed)];
 
-	MD5(u.d, 16, u.d);
+	internal_md5(u.d, 16, u.d);
 	return u.rval;
 	}
 

--- a/src/util.cc
+++ b/src/util.cc
@@ -41,6 +41,7 @@
 # include <malloc.h>
 #endif
 
+#include "digest.h"
 #include "input.h"
 #include "util.h"
 #include "Obj.h"
@@ -712,12 +713,12 @@ void hmac_md5(size_t size, const unsigned char* bytes, unsigned char digest[16])
 	if ( ! hmac_key_set )
 		reporter->InternalError("HMAC-MD5 invoked before the HMAC key is set");
 
-	MD5(bytes, size, digest);
+	internal_md5(bytes, size, digest);
 
 	for ( int i = 0; i < 16; ++i )
 		digest[i] ^= shared_hmac_md5_key[i];
 
-	MD5(digest, 16, digest);
+	internal_md5(digest, 16, digest);
 	}
 
 static bool read_random_seeds(const char* read_file, uint32* seed,
@@ -871,7 +872,7 @@ void init_random_seed(const char* read_file, const char* write_file)
 	if ( ! hmac_key_set )
 		{
 		assert(sizeof(buf) - 16 == 64);
-		MD5((const u_char*) buf, sizeof(buf) - 16, shared_hmac_md5_key); // The last 128 bits of buf are for siphash
+		internal_md5((const u_char*) buf, sizeof(buf) - 16, shared_hmac_md5_key); // The last 128 bits of buf are for siphash
 		hmac_key_set = true;
 		}
 


### PR DESCRIPTION
This allows bro to run properly on a properly on a FIPS-enabled system. It should not change any actual functionality of Bro.