### PR TITLE
Minor signal handling tweaks

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -392,9 +392,7 @@ void termination_signal()
 	(void) setsignal(SIGTERM, SIG_DFL);
 	(void) setsignal(SIGINT, SIG_DFL);
 	set_processing_status("TERMINATING", "termination_signal");
-
-	Val sval(signal_val, TYPE_COUNT);
-	reporter->Info("received termination signal");
+	reporter->Info("received termination signal %d", signal_val);
 	net_get_final_stats();
 	done_with_network();
 	net_delete();

--- a/src/main.cc
+++ b/src/main.cc
@@ -389,6 +389,8 @@ void terminate_bro()
 
 void termination_signal()
 	{
+	(void) setsignal(SIGTERM, SIG_DFL);
+	(void) setsignal(SIGINT, SIG_DFL);
 	set_processing_status("TERMINATING", "termination_signal");
 
 	Val sval(signal_val, TYPE_COUNT);

--- a/testing/btest/Baseline/core.when-interpreter-exceptions/bro.output
+++ b/testing/btest/Baseline/core.when-interpreter-exceptions/bro.output
@@ -2,7 +2,7 @@ expression error in /Users/jon/Projects/bro/bro/testing/btest/.tmp/core.when-int
 expression error in /Users/jon/Projects/bro/bro/testing/btest/.tmp/core.when-interpreter-exceptions/when-interpreter-exceptions.bro, line 91: field value missing [myrecord$notset]
 expression error in /Users/jon/Projects/bro/bro/testing/btest/.tmp/core.when-interpreter-exceptions/when-interpreter-exceptions.bro, line 72: field value missing [myrecord$notset]
 expression error in /Users/jon/Projects/bro/bro/testing/btest/.tmp/core.when-interpreter-exceptions/when-interpreter-exceptions.bro, line 103: field value missing [myrecord$notset]
-received termination signal
+received termination signal 15
 [f(F)]
 f() done, no exception, T
 [f(T)]

--- a/testing/btest/Baseline/doc.broxygen.all_scripts/.stderr
+++ b/testing/btest/Baseline/doc.broxygen.all_scripts/.stderr
@@ -8,4 +8,4 @@ warning in /Users/jon/projects/bro/bro/scripts/policy/protocols/dhcp/deprecated_
 warning in /Users/jon/projects/bro/bro/scripts/policy/protocols/dhcp/deprecated_events.bro, line 266: deprecated (dhcp_inform)
 warning in /Users/jon/projects/bro/bro/scripts/policy/protocols/smb/__load__.bro, line 1: deprecated script loaded from /Users/jon/projects/bro/bro/scripts/broxygen/__load__.bro:10 "Use '@load base/protocols/smb' instead"
 error in /Users/jon/projects/bro/bro/scripts/policy/frameworks/control/controller.bro, line 22: The '' control command is unknown.
-<params>, line 1: received termination signal
+<params>, line 1: received termination signal 15

--- a/testing/btest/Baseline/language.expire-expr-error/output
+++ b/testing/btest/Baseline/language.expire-expr-error/output
@@ -1,2 +1,2 @@
 error in /home/robin/bro/master/testing/btest/.tmp/language.expire-expr-error/expire-expr-error.bro, line 8: no such index (x[kaputt])
-received termination signal
+received termination signal 15

--- a/testing/btest/Baseline/scripts.base.frameworks.config.basic/bro..stderr
+++ b/testing/btest/Baseline/scripts.base.frameworks.config.basic/bro..stderr
@@ -1,1 +1,1 @@
-received termination signal
+received termination signal 15

--- a/testing/btest/Baseline/scripts.base.frameworks.input.config.errors/errout
+++ b/testing/btest/Baseline/scripts.base.frameworks.input.config.errors/errout
@@ -10,5 +10,5 @@ error: SendEvent for event InputConfig::new_value failed
 warning: ../configfile/Input::READER_CONFIG: Option 'testbooool' does not exist. Ignoring line.
 warning: ../configfile/Input::READER_CONFIG: Option 'test_any' has type 'any', which is not supported for file input. Ignoring line.
 warning: ../configfile/Input::READER_CONFIG: Option 'test_table' has type 'table', which is not supported for file input. Ignoring line.
-received termination signal
+received termination signal 15
 >>>

--- a/testing/btest/Baseline/scripts.base.frameworks.input.errors/.stderr
+++ b/testing/btest/Baseline/scripts.base.frameworks.input.errors/.stderr
@@ -38,4 +38,4 @@ error: Input stream error2: Error event's first attribute must be of type Input:
 error: Input stream error3: Error event's first attribute must be of type Input::EventDescription
 error: Input stream error4: Error event's second attribute must be of type string
 error: Input stream error5: Error event's third attribute must be of type Reporter::Level
-received termination signal
+received termination signal 15

--- a/testing/btest/Baseline/scripts.base.frameworks.input.invalidnumbers/.stderrwithoutfirstline
+++ b/testing/btest/Baseline/scripts.base.frameworks.input.invalidnumbers/.stderrwithoutfirstline
@@ -4,5 +4,5 @@ warning: ../input.log/Input::READER_ASCII: Number '9223372036854775801TEXTHERE' 
 warning: ../input.log/Input::READER_ASCII: Number '1Justtext' contained non-numeric trailing characters. Ignored trailing characters 'Justtext'
 warning: ../input.log/Input::READER_ASCII: String 'Justtext' contained no parseable number
 warning: ../input.log/Input::READER_ASCII: Could not convert line 'Justtext	1' to Val. Ignoring line.
-received termination signal
+received termination signal 15
 >>>

--- a/testing/btest/Baseline/scripts.base.frameworks.input.invalidset/.stderrwithoutfirstline
+++ b/testing/btest/Baseline/scripts.base.frameworks.input.invalidset/.stderrwithoutfirstline
@@ -4,5 +4,5 @@ warning: ../input.log/Input::READER_ASCII: Could not convert line 'name	127.0.0.
 warning: ../input.log/Input::READER_ASCII: Invalid value for subnet: 127.0.0.1
 warning: ../input.log/Input::READER_ASCII: Error while reading set or vector
 warning: ../input.log/Input::READER_ASCII: Could not convert line 'name	127.0.0.1' to Val. Ignoring line.
-received termination signal
+received termination signal 15
 >>>

--- a/testing/btest/Baseline/scripts.base.frameworks.input.invalidtext/.stderrwithoutfirstline
+++ b/testing/btest/Baseline/scripts.base.frameworks.input.invalidtext/.stderrwithoutfirstline
@@ -2,5 +2,5 @@ warning: ../input.log/Input::READER_ASCII: String 'l' contained no parseable num
 warning: ../input.log/Input::READER_ASCII: Could not convert line '	l' to Val. Ignoring line.
 warning: ../input.log/Input::READER_ASCII: String 'l' contained no parseable number
 warning: ../input.log/Input::READER_ASCII: Could not convert line '	l' to Val. Ignoring line.
-received termination signal
+received termination signal 15
 >>>

--- a/testing/btest/Baseline/scripts.base.frameworks.input.missing-enum/bro..stderr
+++ b/testing/btest/Baseline/scripts.base.frameworks.input.missing-enum/bro..stderr
@@ -1,2 +1,2 @@
 warning: Value 'IdoNot::Exist' for stream 'enum' is not a valid enum.
-received termination signal
+received termination signal 15

--- a/testing/btest/Baseline/scripts.base.frameworks.input.missing-file-initially/bro..stderr
+++ b/testing/btest/Baseline/scripts.base.frameworks.input.missing-file-initially/bro..stderr
@@ -5,4 +5,4 @@ error: ../does-not-exist.dat/Input::READER_ASCII: Init: cannot open ../does-not-
 error: ../does-not-exist.dat/Input::READER_ASCII: Init failed
 error: ../does-not-exist.dat/Input::READER_ASCII: terminating thread
 warning: ../does-not-exist.dat/Input::READER_ASCII: Could not get stat for ../does-not-exist.dat
-received termination signal
+received termination signal 15

--- a/testing/btest/Baseline/scripts.base.frameworks.input.missing-file/bro..stderr
+++ b/testing/btest/Baseline/scripts.base.frameworks.input.missing-file/bro..stderr
@@ -1,4 +1,4 @@
 error: does-not-exist.dat/Input::READER_ASCII: Init: cannot open does-not-exist.dat
 error: does-not-exist.dat/Input::READER_ASCII: Init failed
 error: does-not-exist.dat/Input::READER_ASCII: terminating thread
-received termination signal
+received termination signal 15

--- a/testing/btest/Baseline/scripts.base.frameworks.input.port-embedded/bro..stderr
+++ b/testing/btest/Baseline/scripts.base.frameworks.input.port-embedded/bro..stderr
@@ -1,2 +1,2 @@
 warning: ../input.log/Input::READER_ASCII: Port '50/trash' contained unknown protocol 'trash'
-received termination signal
+received termination signal 15

--- a/testing/btest/Baseline/scripts.base.frameworks.input.sqlite.error/cmpfile
+++ b/testing/btest/Baseline/scripts.base.frameworks.input.sqlite.error/cmpfile
@@ -3,4 +3,4 @@ error: ../ssh/Input::READER_SQLITE: Init failed
 error: ../ssh/Input::READER_SQLITE: Required field vh not found after SQLite statement
 error: ../ssh/Input::READER_SQLITE: SQLite call failed: no such column: g
 error: ../ssh/Input::READER_SQLITE: terminating thread
-received termination signal
+received termination signal 15

--- a/testing/btest/Baseline/scripts.base.frameworks.intel.remove-non-existing/output
+++ b/testing/btest/Baseline/scripts.base.frameworks.intel.remove-non-existing/output
@@ -7,5 +7,5 @@
 #fields	ts	level	message	location
 #types	time	enum	string	string
 0.000000	Reporter::INFO	Tried to remove non-existing item '192.168.1.1' (Intel::ADDR).	/home/jgras/devel/bro/scripts/base/frameworks/intel/./main.bro, lines 547-548
-0.000000	Reporter::INFO	received termination signal	(empty)
+0.000000	Reporter::INFO	received termination signal 15	(empty)
 #close	2018-02-27-17-25-30


### PR DESCRIPTION
Anyone think of a reason not to do this?

I mean it's likely always a bug that needs to be fixed whenever Bro termination hangs, but being able to easily ctrl-c (and have it work the 2nd time) during the process of debugging that underlying issue was something I found helpful.