### PR TITLE
Remove unnecessary Bloom filter check during lookup

### DIFF
--- a/src/probabilistic/bloom-filter.bif
+++ b/src/probabilistic/bloom-filter.bif
@@ -173,9 +173,6 @@ function bloomfilter_lookup%(bf: opaque of bloomfilter, x: any%): count
 	%{
 	const BloomFilterVal* bfv = static_cast<const BloomFilterVal*>(bf);
 
-	if ( bfv->Empty() )
-		return new Val(0, TYPE_COUNT);
-
 	if ( ! bfv->Type() )
 		reporter->Error("cannot perform lookup on untyped Bloom filter");
 


### PR DESCRIPTION
The call to` Empty()` was originally meant as an optimization in the lookup phase. However, the performance implications are substantial: this check operates in *O(f(m/8))* where *m* is the number of bits in the Bloom filters and *f* a function that looks for the first non-empty block
of bits.

As the Bloom filter fills up, the check for `Empty()` becomes no longer negligible and can lead to serious performance degradations when Bloom filters are used frequently.

The performance issue was originally reported by Aashish (@initconf).